### PR TITLE
interface: more user-friendly compression registering

### DIFF
--- a/byteps/common/compressor/base_compressor.cc
+++ b/byteps/common/compressor/base_compressor.cc
@@ -41,11 +41,11 @@ CompressorRegistry::ctor_t CompressorRegistry::Find(const std::string& name) {
 std::unique_ptr<BaseCompressor> CompressorRegistry::Create(
     const kwargs_t& kwargs) {
 #ifndef BYTEPS_BUILDING_SERVER
-  const std::string types[] = {"momentum_type", "error_feedback_type",
+  const std::string types[] = {"momentum_type", "ef_type",
                                 "compressor_type"};
 #else
   // server do not need momentum
-  const std::string types[] = {"error_feedback_type", "compressor_type"};
+  const std::string types[] = {"ef_type", "compressor_type"};
 #endif
   for (auto& type : types) {
     auto iter = kwargs.find(type);

--- a/byteps/common/compressor/strategy/onebit.cc
+++ b/byteps/common/compressor/strategy/onebit.cc
@@ -24,7 +24,12 @@ namespace {
 CompressorRegistry::Register reg(
     "onebit_compressor", [](const kwargs_t& kwargs) {
       BPS_LOG(DEBUG) << "Register Onebit Compressor";
-      if (kwargs.find("compressor_onebit_enable_scale") != kwargs.end()) {
+      bool scaled = false;
+      auto iter = kwargs.find("compressor_onebit_scaling");
+      if (iter != kwargs.end() && iter->second == "true") {
+        scaled = true;
+      }
+      if (scaled) {
         return std::unique_ptr<BaseCompressor>(new OnebitCompressor(true));
       }
       return std::unique_ptr<BaseCompressor>(new OnebitCompressor());

--- a/byteps/common/compressor/strategy/onebit.cc
+++ b/byteps/common/compressor/strategy/onebit.cc
@@ -26,8 +26,8 @@ CompressorRegistry::Register reg(
       BPS_LOG(DEBUG) << "Register Onebit Compressor";
       bool scaled = false;
       auto iter = kwargs.find("compressor_onebit_scaling");
-      if (iter != kwargs.end() && iter->second == "true") {
-        scaled = true;
+      if (iter != kwargs.end()) {
+        if (iter->second == "true" || iter->second == "True") scaled = true;
       }
       if (scaled) {
         return std::unique_ptr<BaseCompressor>(new OnebitCompressor(true));

--- a/byteps/common/compressor/strategy/vanilla_error_feedback.cc
+++ b/byteps/common/compressor/strategy/vanilla_error_feedback.cc
@@ -26,11 +26,11 @@ namespace common {
 namespace compressor {
 namespace {
 CompressorRegistry::Register reg(
-    "vanilla_error_feedback",
+    "vanilla_ef",
     [](const kwargs_t& kwargs) -> std::unique_ptr<BaseCompressor> {
       // register cpr
       auto kwargs_clone = kwargs;
-      kwargs_clone.erase("error_feedback_type");
+      kwargs_clone.erase("ef_type");
       auto compressor_ptr = CompressorRegistry::Create(kwargs_clone);
       BPS_CHECK_NE(compressor_ptr, nullptr);
 

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -201,9 +201,12 @@ class DistributedTrainer(mx.gluon.Trainer):
         if isinstance(params, mx.gluon.ParameterDict):
             for key in sorted(list(params.keys())):
                 param_list.append(params[key])
-
+        print(compression_params)
+        
         self._compression = self._register_compressor(
             params, optimizer_params, compression_params)
+        
+        print(optimizer_params)
 
         super(DistributedTrainer, self).__init__(
             param_list, optimizer, optimizer_params=optimizer_params, kvstore=None)
@@ -224,6 +227,7 @@ class DistributedTrainer(mx.gluon.Trainer):
                     filter(lambda attr: attr[0].startswith(
                         "byteps_",), param.__dict__.items())
                 )
+                print("params of %d:" % i, byteps_params)
                 byteps_declare_tensor("gradient_" + str(i), **byteps_params)
 
     def __del__(self):

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -201,12 +201,9 @@ class DistributedTrainer(mx.gluon.Trainer):
         if isinstance(params, mx.gluon.ParameterDict):
             for key in sorted(list(params.keys())):
                 param_list.append(params[key])
-        print(compression_params)
-        
+
         self._compression = self._register_compressor(
             params, optimizer_params, compression_params)
-        
-        print(optimizer_params)
 
         super(DistributedTrainer, self).__init__(
             param_list, optimizer, optimizer_params=optimizer_params, kvstore=None)
@@ -227,7 +224,6 @@ class DistributedTrainer(mx.gluon.Trainer):
                     filter(lambda attr: attr[0].startswith(
                         "byteps_",), param.__dict__.items())
                 )
-                print("params of %d:" % i, byteps_params)
                 byteps_declare_tensor("gradient_" + str(i), **byteps_params)
 
     def __del__(self):
@@ -243,7 +239,7 @@ class DistributedTrainer(mx.gluon.Trainer):
         compression = Compression.none
         if not compression_params:
             return compression
-        
+
         if "fp16" in compression_params:
             compression = Compression.fp16
 

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -181,23 +181,38 @@ class DistributedTrainer(mx.gluon.Trainer):
         Key-word arguments to be passed to optimizer constructor. For example,
         `{'learning_rate': 0.1}`. All optimizers accept learning_rate, wd (weight decay),
         clip_gradient, and lr_scheduler. See each optimizer's
-        constructor for a list of additional supported arguments.
+        constructor for a list of additional supported arguments
+    root_rank : int
+        rank of root
+    compression_params : dict
+        Key-word arguments to be passed to gradient compression constructor. For example, 
+        `{'compressor': 'onebit', 'ef': 'vanilla', 'momentum': 'nesterov', 'scaling': true}`.
+        All compressor accept 'compressor', 'ef'. See each compressor's constructor for a list 
+        of additional supported arguments
+    compression_register_func : func
+        User defined gradient compression register
     """
 
-    def __init__(self, params, optimizer, optimizer_params=None, root_rank=0, compression=Compression.none):
+    def __init__(self, params, optimizer, optimizer_params=None, root_rank=0, compression_params=None, compression_register_func=None):
         if isinstance(optimizer, DistributedOptimizer):
             optimizer = optimizer._optimizer
             warnings.warn("DistributedTrainer does not take DistributedOptimizer "
                           "as its optimizer. We have unwrapped it for you.")
-        self._compression = compression
+
         param_list = []
         if isinstance(params, mx.gluon.ParameterDict):
             for key in sorted(list(params.keys())):
                 param_list.append(params[key])
 
+        # user defined register function
+        if compression_register_func:
+            self._register_compressor = compression_register_func
+        self._register_compressor(
+            params, optimizer_params, compression_params)
+
         super(DistributedTrainer, self).__init__(
             param_list, optimizer, optimizer_params=optimizer_params, kvstore=None)
-        
+
         if local_rank() == 0:
             self._f = open("lr.s", "wb")
             self._f.truncate(8)
@@ -218,6 +233,54 @@ class DistributedTrainer(mx.gluon.Trainer):
 
     def __del__(self):
         self._f.close()
+
+    def _register_compressor(self, params, optimizer_params, compression_params):
+        """Register compressor for BytePS
+
+        params : mx.gluon.ParameterDict 
+        optimizer_params : dict
+        compression_params : dict
+        """
+        self._compression = Compression.none
+        if not compression_params:
+            return 
+        
+        if "fp16" in compression_params:
+            self._compression = Compression.fp16
+
+        if "compressor" not in compression_params:
+            warnings.warn("Compressor is not defined")
+            return 
+
+        check_list = ["compressor", "ef", "momentum"]
+
+        for _, param in params.items():
+            # generic
+            for item in check_list:
+                if item in compression_params:
+                    if isinstance(compression_params[item], str):
+                        setattr(param, "byteps_%s_type" %
+                                item, compression_params[item])
+                    else:
+                        raise TypeError("%s should be str" % item)
+
+            # need parameter
+            compressor = compression_params["compressor"]
+            if compressor == "onebit":
+                setattr(param, "byteps_compressor_onebit_scaling", str(
+                    compression_params.get("scaling", False)))
+            elif compressor == "topk" or compressor == "randomk" or compressor == "multibit":
+                # raise KeyError if 'k' is not found
+                setattr(param, "byteps_compressor_k",
+                        compression_params["k"])
+
+            if "momentum" in compression_params:
+                setattr(param, "byteps_momentum_mu",
+                        optimizer_params["momentum"])
+
+        # change
+        if "momentum" in compression_params:
+            del optimizer_params['momentum']
 
     def step(self, batch_size, ignore_stale_grad=False):
         self._scale = batch_size

--- a/example/mxnet/train_gluon_imagenet_byteps_gc.py
+++ b/example/mxnet/train_gluon_imagenet_byteps_gc.py
@@ -397,15 +397,15 @@ def main():
             for k, v in net.collect_params('.*beta|.*gamma|.*bias').items():
                 v.wd_mult = 0.0
 
-        params = net.collect_params()
+        compression_params = {
+            "compressor": opt.compressor,
+            "ef": opt.ef,
+            "momentum": opt.momentum,
+            "scaling": opt.scaling
+        }
 
         trainer = bps.DistributedTrainer(
-            params, optimizer, optimizer_params, {
-                "compressor": opt.compressor,
-                "ef": opt.ef,
-                "momentum": opt.momentum,
-                "scaling": opt.scaling
-            })
+            net.collect_params(), optimizer, optimizer_params, compression_params)
 
         if opt.resume_states is not '':
             trainer.load_states(opt.resume_states)

--- a/example/mxnet/train_gluon_imagenet_byteps_gc.py
+++ b/example/mxnet/train_gluon_imagenet_byteps_gc.py
@@ -116,14 +116,15 @@ def parse_args():
     # additional arguments for gradient compression
     parser.add_argument('--compressor', type=str, default='',
                         help='which compressor')
-    parser.add_argument('--ef', type=str, default=None,
-                        help='enable error-feedback')
+    parser.add_argument('--ef', type=str, default='',
+                        help='which error-feedback')
+    parser.add_argument('--compress-momentum', type=str, default='',
+                        help='which compress momentum')
     parser.add_argument('--onebit-scaling', action='store_true', default=False,
                         help='enable scaling for onebit compressor')
     parser.add_argument('--fp16-pushpull', action='store_true', default=False,
                         help='use fp16 compression during pushpull')
-    parser.add_argument('--compress-momentum', action='store_true', default=False,
-                        help='enable compress momentum.')
+
     opt = parser.parse_args()
     return opt
 
@@ -400,7 +401,7 @@ def main():
         compression_params = {
             "compressor": opt.compressor,
             "ef": opt.ef,
-            "momentum": opt.momentum,
+            "momentum": opt.compress_momentum,
             "scaling": opt.scaling
         }
 

--- a/example/mxnet/train_gluon_imagenet_byteps_gc.py
+++ b/example/mxnet/train_gluon_imagenet_byteps_gc.py
@@ -398,24 +398,15 @@ def main():
                 v.wd_mult = 0.0
 
         params = net.collect_params()
-        if opt.compressor:
-            for _, param in params.items():
-                setattr(param, "byteps_compressor_type", opt.compressor)
-                if opt.ef:
-                    setattr(param, "byteps_error_feedback_type", opt.ef)
-                if opt.onebit_scaling:
-                    setattr(
-                        param, "byteps_compressor_onebit_enable_scale", opt.onebit_scaling)
-                if opt.compress_momentum:
-                    setattr(param, "byteps_momentum_type", "nesterov")
-                    setattr(param, "byteps_momentum_mu", opt.momentum)
 
-        if opt.compress_momentum:
-            del optimizer_params['momentum']
-
-        compression = bps.Compression.fp16 if opt.fp16_pushpull else bps.Compression.none
         trainer = bps.DistributedTrainer(
-            params, optimizer, optimizer_params, compression=compression)
+            params, optimizer, optimizer_params, {
+                "compressor": opt.compressor,
+                "ef": opt.ef,
+                "momentum": opt.momentum,
+                "scaling": opt.scaling
+            })
+
         if opt.resume_states is not '':
             trainer.load_states(opt.resume_states)
 

--- a/example/mxnet/train_gluon_imagenet_byteps_gc.py
+++ b/example/mxnet/train_gluon_imagenet_byteps_gc.py
@@ -405,7 +405,7 @@ def main():
         }
 
         trainer = bps.DistributedTrainer(
-            net.collect_params(), optimizer, optimizer_params, compression_params)
+            net.collect_params(), optimizer, optimizer_params, compression_params=compression_params)
 
         if opt.resume_states is not '':
             trainer.load_states(opt.resume_states)

--- a/example/mxnet/train_gluon_mnist_byteps_gc.py
+++ b/example/mxnet/train_gluon_mnist_byteps_gc.py
@@ -45,15 +45,15 @@ parser.add_argument('--momentum', type=float, default=0.9,
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disable training on GPU (default: False)')
 parser.add_argument('--compressor', type=str, default='',
-                    help='onebit compressor')
+                    help='which compressor')
 parser.add_argument('--ef', type=str, default=None,
-                    help='ef')
+                    help='which error feedback')
+parser.add_argument('--compress-momentum', type=str, default='',
+                    help='which compress momentum')
 parser.add_argument('--scaling', action='store_true', default=False,
                     help='enable scaling for onebit compressor')
 parser.add_argument('--fp16-pushpull', action='store_true', default=False,
                     help='use fp16 compression during pushpull')
-parser.add_argument('--compress-momentum', action='store_true', default=False,
-                    help='enable compress momentum.')
 args = parser.parse_args()
 
 if not args.no_cuda:
@@ -139,7 +139,7 @@ optimizer_params = {'momentum': args.momentum,
 compression_params = {
     "compressor": args.compressor,
     "ef": args.ef,
-    "momentum": args.momentum,
+    "momentum": args.compress_momentum,
     "scaling": args.scaling
 }
 

--- a/example/mxnet/train_gluon_mnist_byteps_gc.py
+++ b/example/mxnet/train_gluon_mnist_byteps_gc.py
@@ -144,7 +144,7 @@ compression_params = {
 }
 
 trainer = bps.DistributedTrainer(
-    params, "sgd", optimizer_params, compression_params)
+    params, "sgd", optimizer_params, compression_params=compression_params)
 
 # Create loss function and train metric
 loss_fn = gluon.loss.SoftmaxCrossEntropyLoss()

--- a/example/mxnet/train_gluon_mnist_byteps_gc.py
+++ b/example/mxnet/train_gluon_mnist_byteps_gc.py
@@ -136,13 +136,15 @@ params = model.collect_params()
 optimizer_params = {'momentum': args.momentum,
                     'learning_rate': args.lr * num_workers}
 
+compression_params = {
+    "compressor": args.compressor,
+    "ef": args.ef,
+    "momentum": args.momentum,
+    "scaling": args.scaling
+}
+
 trainer = bps.DistributedTrainer(
-    params, "sgd", optimizer_params, {
-        "compressor": args.compressor,
-        "ef": args.ef,
-        "momentum": args.momentum, 
-        "scaling": args.scaling
-    })
+    params, "sgd", optimizer_params, compression_params)
 
 # Create loss function and train metric
 loss_fn = gluon.loss.SoftmaxCrossEntropyLoss()


### PR DESCRIPTION
## design

move compression registering into `bps.DistributedTrainer(mx.gluon.Trainer)`. Users only need to pass `compression_params` like `optimizer_params`. Hiding this logic eases users' difficulty in use. 

before:
```python
params = model.collect_params()

for name, param in params.items():
    assert isinstance(param, mx.gluon.Parameter)
    if args.compressor:
        setattr(param, "byteps_compressor_type", args.compressor)
    if args.ef:
        setattr(param, "byteps_error_feedback_type", args.ef)
    if args.scaling:
        setattr(param, "byteps_compressor_onebit_enable_scale", args.scaling)
    if args.compress_momentum:
        setattr(param, "byteps_momentum_type", "nesterov")
        setattr(param, "byteps_momentum_mu", args.momentum)


# BytePS: create DistributedTrainer, a subclass of gluon.Trainer
optimizer_params = {'momentum': args.momentum,
                    'learning_rate': args.lr * num_workers}

if args.compress_momentum or args.momentum == 0.0:
    del optimizer_params['momentum']

compression = bps.Compression.fp16 if args.fp16_pushpull else bps.Compression.none
trainer = bps.DistributedTrainer(
    params, "sgd", optimizer_params, compression=compression)
```

after:
```python
params = model.collect_params()

# BytePS: create DistributedTrainer, a subclass of gluon.Trainer
optimizer_params = {'momentum': args.momentum,
                    'learning_rate': args.lr * num_workers}

compression_params = {
    "compressor": args.compressor,
    "ef": args.ef,
    "momentum": args.compress_momentum,
    "scaling": args.scaling
}

trainer = bps.DistributedTrainer(
    params, "sgd", optimizer_params, compression_params=compression_params)
```

Some advanced users may want the flexibility to apply specific algorithm to specific parameters.  Then we suggest that they define their own compression registering funciton and bind the function with `bps.DistributedTrainer`. For example,

```python
def user_defined_register_func(self, params, optimizer_params, compression_params=compression_params):
    ...

bps.DistributedTrainer._register_compressor = user_defined_register_func
trainer = bps.DistributedTrainer(params, "sgd", optimizer_params, compression_params)

```


## implementation 

A function in `bps.DistributedTrainer` is added to implement registration logic.

```python
def _register_compressor(self, params, optimizer_params, compression_params):
    """Register compressor for BytePS

    params : mx.gluon.ParameterDict 
    optimizer_params : dict
    compression_params : dict
    """
    ...
```

Then the function is called in `__init__`, before `super`. (because `_register_compressor` may change `optimizer_params`. )



