### PR TITLE
compression: async wd momentum 

### DIFF
--- a/byteps/common/compressor/strategy/onebit.cc
+++ b/byteps/common/compressor/strategy/onebit.cc
@@ -160,7 +160,6 @@ void OnebitCompressor::Decompress(ByteBuf compressed, int dtype,
 
 void OnebitCompressor::Decompress(ByteBuf compressed, int dtype,
                                   ByteBuf& decompressed) {
-  float scale;
   if (decompressed.data == nullptr) decompressed.data = _buf.get();
   Unpacking(decompressed.data, compressed.data, compressed.size, dtype);
 }

--- a/byteps/common/cpu_reducer.cc
+++ b/byteps/common/cpu_reducer.cc
@@ -17,8 +17,6 @@
 #include "global.h"
 #endif
 
-#include <omp.h>
-
 #include <cmath>
 
 #include "cpu_reducer.h"
@@ -44,7 +42,7 @@ CpuReducer::CpuReducer(std::shared_ptr<BytePSComm> comm) {
   if (getenv("BYTEPS_OMP_THREAD_PER_GPU")) {
     _num_threads = atoi(getenv("BYTEPS_OMP_THREAD_PER_GPU"));
   } else {
-    _num_threads = 1;
+    _num_threads = 4;
   }
   return;
 }
@@ -249,16 +247,17 @@ int CpuReducer::_sum_float16(void* dst, const void* src1, const void* src2,
 }
 
 int CpuReducer::copy(void* dst, const void* src, size_t len) {
-  auto in = reinterpret_cast<const float*>(src);
-  auto out = reinterpret_cast<float*>(dst);
-#pragma omp parallel for simd num_threads(_num_threads)
-  for (size_t i = 0; i < len / 4; ++i) {
-    out[i] = in[i];
-  }
-  if (len % 4) {
-    std::memcpy(out + len / 4, in + len / 4, len % 4);
-  }
-  return 0;
+//   auto in = reinterpret_cast<const float*>(src);
+//   auto out = reinterpret_cast<float*>(dst);
+// #pragma omp parallel for simd num_threads(_num_threads)
+//   for (size_t i = 0; i < len / 4; ++i) {
+//     out[i] = in[i];
+//   }
+//   if (len % 4) {
+//     std::memcpy(out + len / 4, in + len / 4, len % 4);
+//   }
+//   return 0;
+  std::memcpy(dst, src, len);
 }
 
 int CpuReducer::sign(void* dst, const void* src, size_t len, DataType dtype) {

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -324,9 +324,7 @@ class DistributedTrainer(mx.gluon.Trainer):
 
                 if rank() != self.root_rank:
                     param_arrays[0].__imul__(0)
-                # compressed, ctx = self._compression.compress(param_arrays[0])
                 byteps_push_pull(param_arrays[0], version=0, priority=0,
                                  name="parameter_" + str(idx), is_average=False)
-                # param.set_data(self._compression.decompress(compressed, ctx))
 
         self._params_to_init = tensors

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -307,11 +307,11 @@ class DistributedTrainer(mx.gluon.Trainer):
                 nd._internal._mul_scalar(
                     param._grad[0], 1.0 / self._scale / self._bps_size, out=param._grad[0])
                 compressed, ctx = self._intra_compressors[i].compress(
-                    param._grad[0])
+                    param._grad[0], x=param._data[0])
                 byteps_push_pull(compressed, is_average=False,
                                  name="gradient_" + str(i), priority=-i)
                 param._grad[0] = self._intra_compressors[i].decompress(
-                    compressed, ctx, x=param._data[0])
+                    compressed, ctx)
 
     def _init_params(self):
         tensors = []

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -222,7 +222,7 @@ class DistributedTrainer(mx.gluon.Trainer):
         for i, param in enumerate(self._params):
             byteps_declare_tensor("parameter_" + str(i))
             if param.grad_req != 'null':
-                self._intra_compressors[i] = copy.deepcopy(
+                self._intra_compressors[i] = copy.copy(
                     self._intra_compressor)
                 byteps_params = dict(
                     filter(lambda attr: attr[0].startswith(

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -78,10 +78,7 @@ class WeightDecayMomentum(Compressor):
 
     @staticmethod
     def _wd_mom(x, mom, cache, wd, mu):
-        nd._internal._mul_scalar(x, wd, out=cache)
-        mom += cache
-        nd._internal._mul_scalar(mom, mu, out=mom)
-        cache += mom
+        pass
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -16,7 +16,6 @@
 """Gradient compression algorithms."""
 
 from multiprocessing import Pool, TimeoutError
-import warnings
 
 import mxnet
 import mxnet.ndarray as nd
@@ -96,7 +95,7 @@ class WeightDecayMomentum(Compressor):
             self.cache = nd.zeros_like(x)
         
         self.res = self.p.apply_async(
-            self._wd_mom, (x, self.mom, self.cache, self.wd, self.mu))
+            WeightDecayMomentum._wd_mom, (x, self.mom, self.cache, self.wd, self.mu))
         return self.compressor.compress(tensor)
 
     def decompress(self, tensor, ctx, *args, **kwargs):
@@ -105,10 +104,10 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         try:
-            self.res.get(timeout=0.5)
+            self.res.get(timeout=1)
             tensor += self.cache
         except TimeoutError:
-            warnings.warn("Wd momentum timeout alert! timeout=%f" % 0.5)
+            print("Wd momentum timeout alert! timeout=%f" % 1)
 
         return self.compressor.decompress(tensor, ctx)
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -100,8 +100,8 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         try:
-            res = self.res.get(timeout=0.5)
-            tensor += res
+            self.res.get(timeout=0.5)
+            tensor += self.cache
         except TimeoutError:
             warnings.warn("Wd momentum timeout alert! timeout=%f" % 0.5)
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -89,7 +89,7 @@ class WeightDecayMomentum(Compressor):
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""
-        self.res = self.p.apply_async(self._wd_mom, (kwargs["x"],))
+        self.res = self.p.apply_async(self._wd_mom, (self, kwargs["x"],))
         return self.compressor.compress(tensor)
 
     def decompress(self, tensor, ctx, *args, **kwargs):

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -77,7 +77,10 @@ class WeightDecayMomentum(Compressor):
 
     @staticmethod
     def _wd_mom(x, mom, cache, wd, mu):
-        pass
+        nd._internal._mul_scalar(x, wd, out=cache)
+        mom += cache
+        nd._internal._mul_scalar(mom, mu, out=mom)
+        cache += mom
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -104,12 +104,8 @@ class WeightDecayMomentum(Compressor):
             m_t = \mu * m_{t-1} + wd * x_t
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
-        self.future.result(0.1)
-        if self.future.done():
-            self.done_cnt += 1
-            print("ratio=%f" % self.done_cnt / self.total_cnt)
-            tensor += self.cache
-        self.total_cnt += 1
+        self.future.result()
+        tensor += self.cache
         return self.compressor.decompress(tensor, ctx)
 
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -66,7 +66,7 @@ class FP16Compressor(Compressor):
 
 class WeightDecayMomentum(Compressor):
     """For 1bit compression."""
-    pool = concurrent.futures.ProcessPoolExecutor(max_workers=4)
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=4)
 
     def __init__(self, compressor, mu, wd):
         self.compressor = compressor

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -79,10 +79,12 @@ class WeightDecayMomentum(Compressor):
 
     @staticmethod
     async def _wd_mom(x, mom, cache, wd, mu):
+        print("start")
         nd._internal._mul_scalar(x, wd, out=cache)
         mom += cache
         nd._internal._mul_scalar(mom, mu, out=mom)
         cache += mom
+        print("end")
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -67,7 +67,7 @@ class FP16Compressor(Compressor):
 
 class WeightDecayMomentum(Compressor):
     """For 1bit compression."""
-    p = Pool(4)
+    p = Pool(processes=16)
 
     def __init__(self, compressor, mu, wd):
         self.compressor = compressor
@@ -104,10 +104,12 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         try:
-            self.res.get(timeout=1)
+            self.res.get(timeout=0.1)
             tensor += self.cache
         except TimeoutError:
-            print("Wd momentum timeout alert! timeout=%f" % 1)
+            print("Wd momentum timeout alert! timeout=%f" % 0.1)
+        except AttributeError:
+            pass
 
         return self.compressor.decompress(tensor, ctx)
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -89,7 +89,7 @@ class WeightDecayMomentum(Compressor):
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""
-        self.res = self.p.apply_async(self._wd_mom, kwargs["x"])
+        self.res = self.p.apply_async(self._wd_mom, (kwargs["x"],))
         return self.compressor.compress(tensor)
 
     def decompress(self, tensor, ctx, *args, **kwargs):

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -79,12 +79,10 @@ class WeightDecayMomentum(Compressor):
 
     @staticmethod
     async def _wd_mom(x, mom, cache, wd, mu):
-        print("start")
         nd._internal._mul_scalar(x, wd, out=cache)
         mom += cache
         nd._internal._mul_scalar(mom, mu, out=mom)
         cache += mom
-        print("end")
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""
@@ -106,6 +104,7 @@ class WeightDecayMomentum(Compressor):
             m_t = \mu * m_{t-1} + wd * x_t
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
+        self.future.result(0.1)
         if self.future.done():
             self.done_cnt += 1
             print("ratio=%f" % self.done_cnt / self.total_cnt)

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -74,6 +74,8 @@ class WeightDecayMomentum(Compressor):
         self.mu = mu
         self.wd = wd
         self.loop = asyncio.get_event_loop()
+        self.done_cnt = 0
+        self.total_cnt = 0
 
     @staticmethod
     async def _wd_mom(x, mom, cache, wd, mu):
@@ -103,9 +105,10 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         if self.future.done():
+            self.done_cnt += 1
+            print("ratio=%f" % self.done_cnt / self.total_cnt)
             tensor += self.cache
-        else:
-            print("future not done")
+        self.total_cnt += 1
         return self.compressor.decompress(tensor, ctx)
 
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -77,7 +77,7 @@ class WeightDecayMomentum(Compressor):
         self.wd = wd
 
     @staticmethod
-    def _wd_mom(x, mom, cache, wd, mu):
+    def _wd_mom():
         pass
 
     def compress(self, tensor, *args, **kwargs):
@@ -92,7 +92,7 @@ class WeightDecayMomentum(Compressor):
             self.cache = nd.zeros_like(x)
         
         self.res = self.p.apply_async(
-            WeightDecayMomentum._wd_mom, (x, self.mom, self.cache, self.wd, self.mu))
+            WeightDecayMomentum._wd_mom)
         return self.compressor.compress(tensor)
 
     def decompress(self, tensor, ctx, *args, **kwargs):

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -77,10 +77,7 @@ class WeightDecayMomentum(Compressor):
 
     @staticmethod
     def _wd_mom(x, mom, cache, wd, mu):
-        nd._internal._mul_scalar(x, wd, out=cache)
-        mom += cache
-        nd._internal._mul_scalar(mom, mu, out=mom)
-        cache += mom
+        pass
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""

--- a/byteps/server/server.cc
+++ b/byteps/server/server.cc
@@ -109,9 +109,8 @@ void BytePSServerEngineThread(int i) {
       if (msg.ops == ALL_RECV) {
         // 2. no compress
         auto& updates = update_buf_[msg.key];
-        auto stored = GetStore(msg.key);
-        updates.merged.tensor = stored->tensor;
-        updates.merged.len = stored->len;
+        updates.merged.tensor = reinterpret_cast<char*>(msg.src);
+        updates.merged.len = msg.len;
       }
     }
 


### PR DESCRIPTION
## motivation

Adding wd momentum sacrifices some performance. The performance decreased by about 12.5%. We want to make up this gap. 

## design

wd momentum can be computed ahead of time. using a thread pool to submit jobs is a good idea. 

Why use a thread pool? Because those operations mainly run on GPU, it is asynchronous already. Furthermore, there is a large overhead when using process pool due to parameter passing. 

## implementation 

add a thread pool as a static class member, shared by all instances.
```python
import concurrent.futures 

class WeightDecayMomentum(Compressor):
    pool = concurrent.futures.ThreadPoolExecutor(max_workers=4)
    ...
```