### PR TITLE
hotfix: use default num_threads

### DIFF
--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -66,7 +66,7 @@ class FP16Compressor(Compressor):
 
 class WeightDecayMomentum(Compressor):
     """For 1bit compression."""
-    pool = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+    pool = concurrent.futures.ThreadPoolExecutor()
 
     def __init__(self, compressor, mu, wd):
         self.compressor = compressor


### PR DESCRIPTION
use defualt number of threads

https://github.com/python/cpython/blob/master/Lib/concurrent/futures/thread.py#L136