### PR TITLE
hotfix: use concurrent.futures.Timeout

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -230,9 +230,6 @@ class DistributedTrainer(mx.gluon.Trainer):
                 )
                 byteps_declare_tensor("gradient_" + str(i), **byteps_params)
 
-    def __del__(self):
-        self._f.close()
-
     def _register_compressor(self, params, optimizer_params, compression_params):
         """Register compressor for BytePS
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -103,7 +103,7 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         try:
-            self.future.result(timeout=1e-6)
+            self.future.result(timeout=0.1)
             tensor += self.cache
         except concurrent.futures.TimeoutError:
             print("timeout for wd-momentum")

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -103,7 +103,7 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         try:
-            self.future.result(timeout=0.01)
+            self.future.result(timeout=1e-6)
             tensor += self.cache
         except concurrent.futures.TimeoutError:
             print("timeout for wd-momentum")

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -103,10 +103,10 @@ class WeightDecayMomentum(Compressor):
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
         try:
-            self.future.result(timeout=0.1)
+            self.future.result(timeout=0.01)
             tensor += self.cache
-        except TimeoutError:
-            print("timeout")
+        except concurrent.futures.TimeoutError:
+            print("timeout for wd-momentum")
         return self.compressor.decompress(tensor, ctx)
 
 


### PR DESCRIPTION
It is [concurrent.futures.TimeoutError](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.TimeoutError), not [TimeoutError](https://docs.python.org/3/library/exceptions.html#TimeoutError). 