### PR TITLE
compression: speed up wd momentum with threading.Thread

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -222,8 +222,8 @@ class DistributedTrainer(mx.gluon.Trainer):
         for i, param in enumerate(self._params):
             byteps_declare_tensor("parameter_" + str(i))
             if param.grad_req != 'null':
-                self._intra_compressors[i] = copy.deepcopy(
-                    self._intra_compressor)
+                self._intra_compressors[i] = type(self._intra_compressor)(
+                    **self._intra_compressor.__dict__)
                 byteps_params = dict(
                     filter(lambda attr: attr[0].startswith(
                         "byteps_",), param.__dict__.items())

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -222,7 +222,7 @@ class DistributedTrainer(mx.gluon.Trainer):
         for i, param in enumerate(self._params):
             byteps_declare_tensor("parameter_" + str(i))
             if param.grad_req != 'null':
-                self._intra_compressors[i] = copy.copy(
+                self._intra_compressors[i] = copy.deepcopy(
                     self._intra_compressor)
                 byteps_params = dict(
                     filter(lambda attr: attr[0].startswith(

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -86,6 +86,7 @@ class WeightDecayMomentum(Compressor):
         cache = None
         for i, x in iter(input.get, 'STOP'):
             if mom is None:
+                print(x.context)
                 mom = nd.zeros_like(x)
                 cache = nd.zeros_like(x)
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -17,8 +17,9 @@
 import mxnet
 import mxnet.ndarray as nd
 
-from multiprocessing import Process, Queue, TimeoutError
-from multiprocessing.queues import Empty
+import threading
+from queue import Queue, Empty
+
 
 class Compressor(object):
     """Interface for compressing and decompressing a given tensor."""
@@ -74,8 +75,8 @@ class WeightDecayMomentum(Compressor):
         self.cnt = 0
         self.task_queue = Queue()
         self.done_queue = Queue()
-        Process(target=self._worker, args=(
-            self.mu, self.wd, self.task_queue, self.done_queue)).start()
+        threading.Thread(target=self._worker, args=(
+            self.mu, self.wd, self.task_queue, self.done_queue), daemon=True).start()
 
     def __del__(self):
         self.task_queue.put('STOP')

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -81,7 +81,7 @@ class WeightDecayMomentum(Compressor):
         self.task_queue.put('STOP')
 
     @staticmethod
-    def _worker(wd, mu, input, output):
+    def _worker(mu, wd, input, output):
         mom = None
         cache = None
         for x, _ in iter(input.get, 'STOP'):

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -86,7 +86,7 @@ class WeightDecayMomentum(Compressor):
         cache = None
         for i, x in iter(input.get, 'STOP'):
             if mom is None:
-                print(x.context)
+                print("after", x.context)
                 mom = nd.zeros_like(x)
                 cache = nd.zeros_like(x)
 
@@ -102,6 +102,7 @@ class WeightDecayMomentum(Compressor):
             return self.compressor.compress(tensor)
 
         x = kwargs["x"]
+        print("before", x.context)
         self.task_queue.put((self.cnt, x))
         self.cnt += 1
         return self.compressor.compress(tensor)

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -18,7 +18,7 @@ import mxnet
 import mxnet.ndarray as nd
 
 from multiprocessing import Process, Queue, TimeoutError
-
+from multiprocessing.queues import Empty
 
 class Compressor(object):
     """Interface for compressing and decompressing a given tensor."""
@@ -101,6 +101,7 @@ class WeightDecayMomentum(Compressor):
 
         x = kwargs["x"]
         self.task_queue.put(x)
+        print("put")
         return self.compressor.compress(tensor)
 
     def decompress(self, tensor, ctx, *args, **kwargs):
@@ -110,6 +111,9 @@ class WeightDecayMomentum(Compressor):
         """
         try:
             tensor += self.done_queue.get(timeout=0.1)
+            print("get")
+        except Empty:
+            print("empty for wd-momentum")
         except TimeoutError:
             print("timeout for wd-momentum")
         return self.compressor.decompress(tensor, ctx)

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -68,7 +68,7 @@ class FP16Compressor(Compressor):
 class WeightDecayMomentum(Compressor):
     """For 1bit compression."""
 
-    def __init__(self, compressor, mu, wd):
+    def __init__(self, compressor, mu, wd, *args, **kwargs):
         self.compressor = compressor
         self.mu = mu
         self.wd = wd
@@ -129,3 +129,12 @@ class Compression(object):
 
     """Additional Momentum for weight decay. This is only for 1bit. This is a wrapper."""
     wdmom = WeightDecayMomentum
+
+
+# if __name__ == "__main__":
+#     x = WeightDecayMomentum(Compression.none, 0.9, 1e-4)
+#     import copy
+#     print(x.__dict__)
+#     y = type(x)(**x.__dict__)
+#     print(y.__dict__)
+#     print(x.task_queue is y.task_queue)

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -72,7 +72,6 @@ class WeightDecayMomentum(Compressor):
         self.compressor = compressor
         self.mu = mu
         self.wd = wd
-        self.cnt = 0
         self.task_queue = Queue()
         self.done_queue = Queue()
         threading.Thread(target=self._worker, args=(
@@ -85,9 +84,8 @@ class WeightDecayMomentum(Compressor):
     def _worker(wd, mu, input, output):
         mom = None
         cache = None
-        for i, x in iter(input.get, 'STOP'):
+        for x, _ in iter(input.get, 'STOP'):
             if mom is None:
-                print("after", x.context)
                 mom = nd.zeros_like(x)
                 cache = nd.zeros_like(x)
 
@@ -103,9 +101,7 @@ class WeightDecayMomentum(Compressor):
             return self.compressor.compress(tensor)
 
         x = kwargs["x"]
-        print("before", x.context)
-        self.task_queue.put((self.cnt, x))
-        self.cnt += 1
+        self.task_queue.put((x, None))
         return self.compressor.compress(tensor)
 
     def decompress(self, tensor, ctx, *args, **kwargs):


### PR DESCRIPTION
ThreadPool still have some overhead because target and args are passed every time, many of which are unnecessary to be passed. Using a daemon thread would alleviate the issue. It does have some performance gain compared to the previous implementation.

Using multiprocessing.Process maybe the right way to figure it out. But it seems that ndarray's context would be changed when using multiprocessing.Queue. apache/incubator-mxnet#18279