### PR TITLE
compression: add randomk compressor

### DIFF
--- a/byteps/common/compressor/strategy/onebit.h
+++ b/byteps/common/compressor/strategy/onebit.h
@@ -34,7 +34,6 @@ namespace compressor {
  * server: majority vote
  *    sign(\sum_i c_i)
  *
- * \note this is a deterministic algorithm.
  * \note 0 represents positive and 1 represents negative.
  */
 class OnebitCompressor : public BaseCompressor {

--- a/byteps/common/compressor/strategy/randomk.cc
+++ b/byteps/common/compressor/strategy/randomk.cc
@@ -52,7 +52,7 @@ size_t RandomkCompressor::_Packing(index_t* dst, const scalar_t* src,
 
   for (size_t i = 0; i < len; ++i) {
     auto index = dis(_gen);
-    dst[i] = std::make_pair(index, src[index]);
+    ptr[i] = std::make_pair(index, src[index]);
   }
 
   return this->_k * sizeof(pair_t);

--- a/byteps/common/compressor/strategy/randomk.cc
+++ b/byteps/common/compressor/strategy/randomk.cc
@@ -50,7 +50,7 @@ size_t RandomkCompressor::_Packing(index_t* dst, const scalar_t* src,
   std::uniform_int_distribution<> dis(0, len-1);
   auto ptr = reinterpret_cast<pair_t*>(dst);
 
-  for (size_t i = 0; i < len; ++i) {
+  for (size_t i = 0; i < this->_k; ++i) {
     auto index = dis(_gen);
     ptr[i] = std::make_pair(index, src[index]);
   }

--- a/byteps/common/compressor/strategy/randomk.cc
+++ b/byteps/common/compressor/strategy/randomk.cc
@@ -37,18 +37,123 @@ CompressorRegistry::Register
         });
 }
 
-RandomkCompressor::RandomkCompressor(int k) : _k(k){};
+RandomkCompressor::RandomkCompressor(int k) : _k(k) { _gen.seed(_rd()); };
 
 RandomkCompressor::~RandomkCompressor() = default;
+template <typename index_t, typename scalar_t>
+size_t RandomkCompressor::_Packing(index_t* dst, const scalar_t* src,
+                                   size_t len) {
+  static_assert(sizeof(index_t) == sizeof(scalar_t),
+                "index_t should be the same size as scalar_t");
+  BPS_CHECK_LE(this->_k, len / 2);
+  using pair_t = std::pair<index_t, scalar_t>;
+  std::uniform_int_distribution<> dis(0, len-1);
+  auto ptr = reinterpret_cast<pair_t*>(dst);
+
+  for (size_t i = 0; i < len; ++i) {
+    auto index = dis(_gen);
+    dst[i] = std::make_pair(index, src[index]);
+  }
+
+  return this->_k * sizeof(pair_t);
+}
+
+size_t RandomkCompressor::Packing(const void* src, size_t size, int dtype) {
+  switch (dtype) {
+    case BYTEPS_INT8:
+      return _Packing(reinterpret_cast<int8_t*>(_buf.get()),
+                      reinterpret_cast<const int8_t*>(src),
+                      size / sizeof(int8_t));
+    case BYTEPS_UINT8:
+      return _Packing(reinterpret_cast<uint8_t*>(_buf.get()),
+                      reinterpret_cast<const uint8_t*>(src),
+                      size / sizeof(uint8_t));
+    // case BYTEPS_FLOAT16:
+    //   return _Packing(reinterpret_cast<int8_t*>(_buf.get()),
+    //                   reinterpret_cast<const int8_t*>(src), size);
+    case BYTEPS_FLOAT32:
+      return _Packing(reinterpret_cast<int32_t*>(_buf.get()),
+                      reinterpret_cast<const float*>(src),
+                      size / sizeof(int32_t));
+    case BYTEPS_FLOAT64:
+      return _Packing(reinterpret_cast<int64_t*>(_buf.get()),
+                      reinterpret_cast<const double*>(src),
+                      size / sizeof(int64_t));
+    default:
+      BPS_CHECK(0) << "Unsupported data type: " << dtype;
+  }
+  return 0;
+}
 
 void RandomkCompressor::Compress(ByteBuf grad, int dtype, ByteBuf& compressed) {
-  // TODO
+  compressed.size = Packing(grad.data, grad.size, dtype);
+  compressed.data = _buf.get();
 }
 
+template <typename index_t, typename scalar_t>
+size_t RandomkCompressor::_Unpacking(scalar_t* dst, const index_t* src,
+                                     size_t len) {
+  static_assert(sizeof(index_t) == sizeof(scalar_t),
+                "index_t should be the same size as scalar_t");
+  using pair_t = std::pair<index_t, scalar_t>;
+  auto ptr = reinterpret_cast<const pair_t*>(src);
+
+  if ((void*)dst == (void*)src) {
+    auto buf = reinterpret_cast<pair_t*>(_buf.get());
+    std::copy(ptr, ptr + len, buf);
+    ptr = const_cast<const pair_t*>(buf);
+  }
+
+  // reset to zeros
+  std::fill(dst, dst + this->_src_len, 0);
+  for (auto i = 0; i < len; ++i) {
+    auto& pair = ptr[i];
+    dst[pair.first] = pair.second;
+  }
+}
+
+size_t RandomkCompressor::Unpacking(void* dst, const void* src, size_t size,
+                                    int dtype) {
+  switch (dtype) {
+    case BYTEPS_INT8:
+      return _Unpacking(reinterpret_cast<int8_t*>(dst),
+                        reinterpret_cast<const int8_t*>(src),
+                        size / sizeof(int8_t) / 2);
+    case BYTEPS_UINT8:
+      return _Unpacking(reinterpret_cast<uint8_t*>(dst),
+                        reinterpret_cast<const uint8_t*>(src),
+                        size / sizeof(uint8_t) / 2);
+    // case BYTEPS_FLOAT16:
+    //   return _Unpacking(reinterpret_cast<int8_t*>(_buf.get()),
+    //                   reinterpret_cast<const int8_t*>(src), size);
+    case BYTEPS_FLOAT32:
+      return _Unpacking(reinterpret_cast<float*>(dst),
+                        reinterpret_cast<const int32_t*>(src),
+                        size / sizeof(float) / 2);
+    case BYTEPS_FLOAT64:
+      return _Unpacking(reinterpret_cast<double*>(dst),
+                        reinterpret_cast<const int64_t*>(src),
+                        size / sizeof(double) / 2);
+    default:
+      BPS_CHECK(0) << "Unsupported data type: " << dtype;
+  }
+  return 0;
+}
+
+#ifndef BYTEPS_BUILDING_SERVER
+// worker version decompressor
 void RandomkCompressor::Decompress(ByteBuf compressed, int dtype,
                                    ByteBuf& decompressed) {
-  // TODO
+  BPS_CHECK(decompressed.data);
+  Unpacking(decompressed.data, compressed.data, compressed.size, dtype);
 }
+#else
+void RandomkCompressor::Decompress(ByteBuf compressed, int dtype,
+                                   ByteBuf& decompressed) {
+  if (decompressed.data == nullptr) decompressed.data = _buf.get();
+  Unpacking(decompressed.data, compressed.data, compressed.size, dtype);
+}
+#endif
 }  // namespace compressor
 }  // namespace common
 }  // namespace byteps

--- a/byteps/common/compressor/strategy/topk.h
+++ b/byteps/common/compressor/strategy/topk.h
@@ -30,7 +30,6 @@ namespace compressor {
  * 
  * sending the most significant entries of the stochastic gradient
  * 
- * \note this is a deterministic algorithm
  */
 class TopkCompressor : public BaseCompressor {
  public:


### PR DESCRIPTION
# randomk 

similar to #10 

randomly  select K entries of the stochastic gradients

## implementation

use [uniform_int_distribution](https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution)

## results


  | k | ef | mom | wall time(s) | val accu
-- | -- | -- | -- | -- | --
exp1 | 1 | no | no | 58.78 | 0.9765
exp2 | 1 | vanilla | no | 61.04 | 0.9814
exp3 | 1 | vanilla | nesterov | 61.97 | 0.989
exp4 | 2 | vanilla | nesterov | 63.09 | 0.9893
exp5 | 3 | vanilla | nesterov | 63.85 | **0.9901**

这都可以收敛的吗orz....