### PR TITLE
random: swtich to xorshift128p rng backend 

### DIFF
--- a/byteps/common/compressor/impl/randomk.cc
+++ b/byteps/common/compressor/impl/randomk.cc
@@ -39,6 +39,7 @@ CompressorRegistry::Register
             return std::unique_ptr<Compressor>(new RandomkCompressor(size, k));
           } else {
             unsigned int seed = std::stoul(iter2->second);
+            BPS_CHECK(seed != 0) << "seed should not be 0";
             return std::unique_ptr<Compressor>(
                 new RandomkCompressor(size, k, seed, true));
           }
@@ -52,11 +53,10 @@ size_t RandomkCompressor::PackingImpl(index_t* dst, const scalar_t* src,
                 "index_t should be the same size as scalar_t");
   BPS_CHECK_LE(this->_k, len / 2);
   using pair_t = std::pair<index_t, scalar_t>;
-  std::uniform_int_distribution<> dis(0, len - 1);
   auto ptr = reinterpret_cast<pair_t*>(dst);
 
   for (size_t i = 0; i < this->_k; ++i) {
-    auto index = dis(_gen);
+    auto index = _rng.Randint(0, len);
     ptr[i] = std::make_pair(index, src[index]);
   }
 

--- a/byteps/common/compressor/impl/randomk.h
+++ b/byteps/common/compressor/impl/randomk.h
@@ -19,6 +19,7 @@
 #include <random>
 
 #include "../compressor.h"
+#include "../utils.h"
 
 namespace byteps {
 namespace common {
@@ -41,9 +42,7 @@ class RandomkCompressor : public Compressor {
                     bool deterministic = false)
       : Compressor(size), _k(k) {
     if (deterministic) {
-      _gen.seed(seed);
-    } else {
-      _gen.seed(_rd());
+      _rng.set_seed(seed);
     }
   };
   virtual ~RandomkCompressor() = default;
@@ -69,8 +68,8 @@ class RandomkCompressor : public Compressor {
   tensor_t Decompress(tensor_t compressed) override;
 
   /*!
-   * \brief faster version of `UpdateError` 
-   * 
+   * \brief faster version of `UpdateError`
+   *
    * 1. e <- p (e is the error and p is the corrected gradient)
    * 2. zero-fill e with selected k indices
    *
@@ -101,7 +100,7 @@ class RandomkCompressor : public Compressor {
  private:
   int _k;
   std::random_device _rd;
-  std::mt19937 _gen;
+  XorShift128PlusBitShifterRNG _rng;
 };
 }  // namespace compressor
 }  // namespace common

--- a/byteps/common/compressor/impl/randomk.h
+++ b/byteps/common/compressor/impl/randomk.h
@@ -42,6 +42,7 @@ class RandomkCompressor : public Compressor {
                     bool deterministic = false)
       : Compressor(size), _k(k) {
     if (deterministic) {
+      BPS_LOG(INFO) << "SET SEED = " << seed;
       _rng.set_seed(seed);
     }
   };

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -265,7 +265,7 @@ class DistributedTrainer(mx.gluon.Trainer):
             if compressor == "onebit":
                 setattr(param, "byteps_compressor_onebit_scaling", str(
                     compression_params.get("scaling", False)))
-            elif compressor == "topk" or compressor == "randomk" or compressor == "multibit":
+            elif compressor == "topk" or compressor == "randomk" or compressor == "dithering":
                 # raise KeyError if 'k' is not found
                 setattr(param, "byteps_compressor_k",
                         compression_params["k"])
@@ -274,7 +274,7 @@ class DistributedTrainer(mx.gluon.Trainer):
                 setattr(param, "byteps_momentum_mu",
                         optimizer_params["momentum"])
 
-            if compression_params.get("seed"):
+            if compression_params.get("seed", None) is not None:
                 setattr(param, "byteps_seed",
                         compression_params["seed"])
 

--- a/tests/run_byteps_test.sh
+++ b/tests/run_byteps_test.sh
@@ -30,6 +30,7 @@ export DMLC_WORKER_ID=0
 export DMLC_ROLE=worker
 export BYTEPS_THREADPOOL_SIZE=4
 export BYTEPS_FORCE_DISTRIBUTED=1
+export BYTEPS_LOG_LEVEL=INFO
 
 if [ "$TEST_TYPE" == "mxnet" ]; then
   echo "TEST MXNET ..."

--- a/tests/test_randomk.py
+++ b/tests/test_randomk.py
@@ -9,12 +9,12 @@ from mxnet import gluon, autograd
 from parameterized import parameterized
 from tqdm import tqdm
 
-from utils import fake_data
+from utils import fake_data, XorShift128PlusBitShifterRNG
 
 
-def randomk(x, k):
+def randomk(x, k, rng):
     y = x.flatten()
-    indices = [np.random.randint(0, len(y) for _ in k]
+    indices = [rng.randint(0, len(y)) for _ in range(k)]
     vals = y[indices]
     y.fill(0)
     for idx, val in zip(indices, vals):
@@ -30,20 +30,20 @@ class RandomkTestCase(unittest.TestCase):
     @parameterized.expand([(1,)])
     def test_randomk(self, k):
         ctx = mx.gpu(0)
-        np.random.seed(2020)
+        # np.random.seed(2020)
         net = get_model("resnet18_v2")
         net.initialize(mx.init.Xavier(), ctx=ctx)
         net.summary(nd.ones((1, 3, 224, 224), ctx=ctx))
 
         # hyper-params
         batch_size = 32
-        optimizer_params = {'momentum': 0.9, 'wd': 1e-4,
+        optimizer_params = {'momentum': 0, 'wd': 0,
                             'learning_rate': 0.01}
 
         compression_params = {
             "compressor": "randomk",
-            "ef": "vanilla",
-            "momentum": "nesterov",
+            # "ef": "vanilla",
+            # "momentum": "nesterov",
             "k": k,
             "seed": 2020
         }
@@ -60,6 +60,8 @@ class RandomkTestCase(unittest.TestCase):
         errors_s = {}
         moms = {}
         wd_moms = {}
+        rngs = {}
+        rngs_s = {}
 
         for i, param in enumerate(trainer._params):
             if param.grad_req != 'null':
@@ -68,6 +70,8 @@ class RandomkTestCase(unittest.TestCase):
                 errors_s[i] = np.zeros_like(params[i])
                 moms[i] = np.zeros_like(params[i])
                 wd_moms[i] = np.zeros_like(params[i])
+                rngs[i] = XorShift128PlusBitShifterRNG(2020, 2020)
+                rngs_s[i] = XorShift128PlusBitShifterRNG(2020, 2020)
 
         for it, batch in tqdm(enumerate(train_data)):
             data = batch[0].as_in_context(ctx)
@@ -92,19 +96,19 @@ class RandomkTestCase(unittest.TestCase):
             for i, param in enumerate(trainer._params):
                 if param.grad_req != "null":
                     g = gs[i] / (batch_size * bps.size())
-                    moms[i] *= 0.9
-                    moms[i] += g
-                    g += 0.9 * moms[i]
-                    g += errors[i]
-                    c = randomk(g, k)
-                    errors[i] = g - c
+                    # moms[i] *= 0.9
+                    # moms[i] += g
+                    # g += 0.9 * moms[i]
+                    # g += errors[i]
+                    c = randomk(g, k, rngs[i])
+                    # errors[i] = g - c
 
                     # c += errors_s[i]
-                    # cs = randomk(c, k)
+                    cs = randomk(c, k, rngs_s[i])
                     # errors_s[i] = c - cs
-                    # c = cs
+                    c = cs
 
-                    c += 1e-4*xs[i]
+                    # c += 1e-4*xs[i]
                     params[i] -= optimizer_params["learning_rate"] * c
 
         cnt = 0

--- a/tests/test_randomk.py
+++ b/tests/test_randomk.py
@@ -111,6 +111,23 @@ class RandomkTestCase(unittest.TestCase):
                     # c += 1e-4*xs[i]
                     params[i] -= optimizer_params["learning_rate"] * c
 
+                    g2 = param._grad[0].asnumpy().flatten()
+                    d = c.flatten()
+                    if not np.allclose(d, g2, atol=np.finfo(np.float32).eps):
+                        print("False")
+
+                        diff = np.abs(d - g2)
+                        print(d) # baseline
+                        print(g2) # byteps
+                        print(diff)
+                        print(it, i, np.max(diff), np.mean(diff), len(diff), c.shape)
+                        idx = np.where(diff > 1e-5)
+                        print("g: ", idx, gs[i].flatten()[idx])
+                        print("g+e: ", idx, g.flatten()[idx])
+                        print("mxnet: ", idx, d[idx])
+                        print("byteps: ", idx, g2[idx])
+                        input()
+
         cnt = 0
         tot = 0
         diffs = []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import mxnet as mx
 import mxnet.ndarray as nd
+import numpy as np
 
 
 def fake_data(dtype="float32", batch_size=32, height=224, width=224, depth=3, num_classes=1000):
@@ -28,18 +29,17 @@ def fake_data(dtype="float32", batch_size=32, height=224, width=224, depth=3, nu
 
 class XorShift128PlusBitShifterRNG:
     def __init__(self, a, b):
-        self.a = a
-        self.b = b
+        self.state = np.array([a, b], dtype=np.uint64)
 
     def xorshift128p(self):
-        t = self.a
-        s = self.b
-        self.a = s
-        t ^= t << 23
-        t ^= t >> 17
-        t ^= s ^ (s >> 26)
-        self.b = t
-        return t + s
+        t = self.state[0]
+        s = self.state[1]
+        self.state[0] = s
+        t ^= t << np.uint64(23)
+        t ^= t >> np.uint64(17)
+        t ^= s ^ (s >> np.uint64(26))
+        self.state[1] = t
+        return int(t + s)
 
     def randint(self, low, high):
         return self.xorshift128p() % (high - low) + low

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,3 +24,22 @@ def fake_data(dtype="float32", batch_size=32, height=224, width=224, depth=3, nu
 
     return mx.gluon.data.DataLoader(fake_dataset, batch_size=batch_size, num_workers=4,
                                     shuffle=True, last_batch='discard')
+
+
+class XorShift128PlusBitShifterRNG:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def xorshift128p(self):
+        t = self.a
+        s = self.b
+        self.a = s
+        t ^= t << 23
+        t ^= t >> 17
+        t ^= s ^ (s >> 26)
+        self.b = t
+        return t + s
+
+    def randint(self, low, high):
+        return self.xorshift128p() % (high - low) + low


### PR DESCRIPTION
##  brief

Previously we use `std::uniform_int_distribution` as our rng. But its behavior is not the same as python's nor numpy's. This hinders our testing. 

As far as we know, `gsl(GNU Scientific Library)` can generate the same random number as numpy does. But it is too slow and even slower than c++'s when enabling O3. 

We want a fast and reproducible rng. We found [xorshift128p](https://en.wikipedia.org/wiki/Xorshift#xorshift+) may meet our demands. It is 20x times faster than c++'s and simple to implement. Hence we choose it. 

Our preliminary exp shows that randomk still works well on mnist after switching to xorshit128p. 

Xorshift128p will also serve as rng of _dithering_. 