### PR TITLE
misc: use macros 

### DIFF
--- a/byteps/common/compressor/common.h
+++ b/byteps/common/compressor/common.h
@@ -31,11 +31,51 @@ typedef struct BPSTensor {
   int dtype;
 
   BPSTensor() : data(nullptr), size(0), dtype(0) {}
-  BPSTensor(byte_t* data, size_t size=0, int dtype=0)
-      : data(data), size(size), dtype(dtype) {}
+  BPSTensor(void* data, size_t size = 0, int dtype = 0)
+      : data(reinterpret_cast<byte_t*>(data)), size(size), dtype(dtype) {}
 } tensor_t;
 
 using kwargs_t = std::unordered_map<std::string, std::string>;
+
+#define COMPRESS_IMPL_SWITCH(dtype, func, dst, src, size)                     \
+  switch (dtype) {                                                            \
+    case BYTEPS_FLOAT32:                                                      \
+      return func(reinterpret_cast<uint32_t*>(dst),                           \
+                  reinterpret_cast<const float*>(src), size / sizeof(float)); \
+    case BYTEPS_FLOAT64:                                                      \
+      return func(reinterpret_cast<uint64_t*>(dst),                           \
+                  reinterpret_cast<const double*>(src),                       \
+                  size / sizeof(double));                                     \
+    default:                                                                  \
+      BPS_CHECK(0) << "Unsupported data type:" << dtype;                      \
+  }
+
+#define DECOMPRESS_IMPL_SWITCH(dtype, func, dst, src, compressed_size)      \
+  switch (dtype) {                                                          \
+    case BYTEPS_FLOAT32:                                                    \
+      return func(reinterpret_cast<float*>(dst),                            \
+                  reinterpret_cast<const uint32_t*>(src), compressed_size); \
+    case BYTEPS_FLOAT64:                                                    \
+      return func(reinterpret_cast<double*>(dst),                           \
+                  reinterpret_cast<const uint64_t*>(src), compressed_size); \
+    default:                                                                \
+      BPS_CHECK(0) << "Unsupported data type:" << dtype;                    \
+  }
+
+#define SWITCH_TO_FAST_UPDATE_ERROR_IMPL_SWITCH(dtype, func, dst, src1, src2, \
+                                                compressed_size)              \
+  switch (dtype) {                                                            \
+    case BYTEPS_FLOAT32:                                                      \
+      return func(reinterpret_cast<float*>(dst),                              \
+                  reinterpret_cast<float*>(src1),                             \
+                  reinterpret_cast<const uint32_t*>(src2), compressed_size);  \
+    case BYTEPS_FLOAT64:                                                      \
+      return func(reinterpret_cast<double*>(dst),                             \
+                  reinterpret_cast<double*>(src1),                            \
+                  reinterpret_cast<const uint64_t*>(src2), compressed_size);  \
+    default:                                                                  \
+      BPS_CHECK(0) << "Unsupported data type:" << dtype;                      \
+  }
 
 }  // namespace compressor
 }  // namespace common

--- a/byteps/common/compressor/compressor.h
+++ b/byteps/common/compressor/compressor.h
@@ -51,8 +51,9 @@ namespace compressor {
  */
 class Compressor {
  public:
-  Compressor(size_t size)
+  Compressor(size_t size, DataType dtype)
       : _size(size),
+        _dtype(dtype),
         _buf(new byte_t[size]),
         _cpu_reducer(new CpuReducer(nullptr)){};
   virtual ~Compressor() = default;
@@ -122,6 +123,8 @@ class Compressor {
 
   /*! \brief original size */
   size_t _size;
+
+  DataType _dtype;
 
   /*! \brief CPU reducer */
   std::unique_ptr<CpuReducer> _cpu_reducer;

--- a/byteps/common/compressor/compressor_registry.cc
+++ b/byteps/common/compressor/compressor_registry.cc
@@ -36,7 +36,7 @@ CompressorRegistry::ctor_t CompressorRegistry::Find(const std::string& name) {
 }
 
 std::unique_ptr<Compressor> CompressorRegistry::Create(const kwargs_t& kwargs,
-                                                       size_t size, int dtype) {
+                                                       size_t size, DataType dtype) {
 #ifndef BYTEPS_BUILDING_SERVER
   const std::string types[] = {"momentum_type", "ef_type", "compressor_type"};
 #else

--- a/byteps/common/compressor/compressor_registry.h
+++ b/byteps/common/compressor/compressor_registry.h
@@ -26,7 +26,7 @@ class CompressorRegistry {
  public:
   // constructor of compressor
   using ctor_t = std::function<std::unique_ptr<Compressor>(
-      const kwargs_t& kwargs, size_t size, int dtype)>;
+      const kwargs_t& kwargs, size_t size, DataType dtype)>;
 
   using map_t = std::unordered_map<std::string, ctor_t>;
 
@@ -37,7 +37,7 @@ class CompressorRegistry {
   static ctor_t Find(const std::string& name);
 
   static std::unique_ptr<Compressor> Create(const kwargs_t& kwargs, size_t size,
-                                            int dtype);
+                                            DataType dtype);
 
  private:
   static map_t _ctor_map;

--- a/byteps/common/compressor/error_feedback.h
+++ b/byteps/common/compressor/error_feedback.h
@@ -48,8 +48,10 @@ namespace compressor {
 class ErrorFeedback : public Compressor {
  public:
   // error buffer should be cleared to zeros at the beginning.
-  ErrorFeedback(size_t size, std::unique_ptr<Compressor> cptr)
-      : Compressor(size), _cptr(std::move(cptr)), _error(new byte_t[size]()) {}
+  ErrorFeedback(size_t size, DataType dtype, std::unique_ptr<Compressor> cptr)
+      : Compressor(size, dtype),
+        _cptr(std::move(cptr)),
+        _error(new byte_t[size]()) {}
   virtual ~ErrorFeedback() = default;
 
   virtual tensor_t Compress(tensor_t grad) final;

--- a/byteps/common/compressor/impl/dithering.cc
+++ b/byteps/common/compressor/impl/dithering.cc
@@ -23,7 +23,7 @@ namespace {
 CompressorRegistry::Register
     reg("dithering_compressor",
         [](const kwargs_t& kwargs, size_t size,
-           int dtype) -> std::unique_ptr<Compressor> {
+           DataType dtype) -> std::unique_ptr<Compressor> {
           auto iter = kwargs.find("compressor_k");
           if (iter == kwargs.end()) {
             BPS_LOG(WARNING)
@@ -33,7 +33,8 @@ CompressorRegistry::Register
           int k = std::stoi(iter->second);
           BPS_LOG(DEBUG) << "Register Multibit Compressor "
                          << "k=" << k;
-          return std::unique_ptr<Compressor>(new DitheringCompressor(size, k));
+          return std::unique_ptr<Compressor>(
+              new DitheringCompressor(size, dtype, k));
         });
 }
 

--- a/byteps/common/compressor/impl/dithering.h
+++ b/byteps/common/compressor/impl/dithering.h
@@ -27,7 +27,8 @@ namespace compressor {
  */
 class DitheringCompressor : public Compressor {
  public:
-  DitheringCompressor(size_t size, int k) : Compressor(size), _k(k){};
+  DitheringCompressor(size_t size, DataType dtype, int k)
+      : Compressor(size, dtype), _k(k){};
   virtual ~DitheringCompressor() = default;
 
   tensor_t Compress(tensor_t grad) override;

--- a/byteps/common/compressor/impl/nesterov_momentum.cc
+++ b/byteps/common/compressor/impl/nesterov_momentum.cc
@@ -23,12 +23,11 @@ namespace {
 CompressorRegistry::Register reg(
     "nesterov_momentum",
     [](const kwargs_t& kwargs, size_t size,
-       int dtype) -> std::unique_ptr<Compressor> {
+       DataType dtype) -> std::unique_ptr<Compressor> {
       // register cpr
       auto kwargs_clone = kwargs;
       kwargs_clone.erase("momentum_type");
-      auto cptr =
-          CompressorRegistry::Create(kwargs_clone, size, dtype);
+      auto cptr = CompressorRegistry::Create(kwargs_clone, size, dtype);
       BPS_CHECK_NE(cptr, nullptr);
       // find \mu
       auto iter = kwargs.find("momentum_mu");
@@ -36,7 +35,7 @@ CompressorRegistry::Register reg(
       float mu = std::stof(iter->second);
       BPS_LOG(DEBUG) << "with momentum";
       return std::unique_ptr<NesterovMomentumCompressor>(
-          new NesterovMomentumCompressor(size, std::move(cptr), mu));
+          new NesterovMomentumCompressor(size, dtype, std::move(cptr), mu));
     });
 }
 

--- a/byteps/common/compressor/impl/nesterov_momentum.h
+++ b/byteps/common/compressor/impl/nesterov_momentum.h
@@ -27,16 +27,16 @@ namespace compressor {
  *
  * paper: A method for solving the convex programming problem with convergence
  * rate $O (1/k^2)$
- * 
+ *
  * m_t <- \mu m_{t-1} + g_t
  * g_t <- \mu m_t + g_t
- * 
+ *
  */
 class NesterovMomentumCompressor : public Momentum {
  public:
-  NesterovMomentumCompressor(size_t size, std::unique_ptr<Compressor> cptr,
-                             float mu)
-      : Momentum(size, std::move(cptr), mu){};
+  NesterovMomentumCompressor(size_t size, DataType dtype,
+                             std::unique_ptr<Compressor> cptr, float mu)
+      : Momentum(size, dtype, std::move(cptr), mu){};
   virtual ~NesterovMomentumCompressor() = default;
 
  protected:

--- a/byteps/common/compressor/impl/onebit.h
+++ b/byteps/common/compressor/impl/onebit.h
@@ -38,8 +38,8 @@ namespace compressor {
  */
 class OnebitCompressor : public Compressor {
  public:
-  OnebitCompressor(size_t size, bool use_scale = false)
-      : Compressor(size), _use_scale(use_scale) {}
+  OnebitCompressor(size_t size, DataType dtype, bool use_scale = false)
+      : Compressor(size, dtype), _use_scale(use_scale) {}
   virtual ~OnebitCompressor() = default;
 
   /*!
@@ -74,19 +74,16 @@ class OnebitCompressor : public Compressor {
                        tensor_t compressed) override;
 
  private:
-  size_t Packing(const void* src, size_t len, int dtype);
-
   template <typename index_t, typename scalar_t>
-  size_t PackingImpl(index_t* dst, const scalar_t* src, size_t len);
-
-  void Unpacking(void* dst, const void* src, size_t len, int dtype);
+  tensor_t CompressImpl(index_t* dst, const scalar_t* src, size_t len);
 
   template <typename scalar_t, typename index_t>
-  void UnpackingImpl(scalar_t* dst, const index_t* src, size_t size);
+  tensor_t DecompressImpl(scalar_t* dst, const index_t* src,
+                          size_t compressed_size);
 
   template <typename scalar_t, typename index_t>
   void FastUpdateErrorImpl(scalar_t* error, scalar_t* corrected,
-                           index_t* compressed, float scale, size_t len);
+                           const index_t* compressed, size_t compressed_size);
 
  private:
   bool _use_scale;

--- a/byteps/common/compressor/impl/randomk.cc
+++ b/byteps/common/compressor/impl/randomk.cc
@@ -20,34 +20,34 @@ namespace byteps {
 namespace common {
 namespace compressor {
 namespace {
-CompressorRegistry::Register
-    reg("randomk_compressor",
-        [](const kwargs_t& kwargs, size_t size,
-           int dtype) -> std::unique_ptr<Compressor> {
-          auto iter = kwargs.find("compressor_k");
-          if (iter == kwargs.end()) {
-            BPS_LOG(FATAL)
-                << "Randomk Compressor needs parameter \"compressor_k\"";
-          }
-          int k = std::stoi(iter->second);
-          BPS_LOG(DEBUG) << "Register Randomk Compressor "
-                         << "k=" << k;
+CompressorRegistry::Register reg(
+    "randomk_compressor",
+    [](const kwargs_t& kwargs, size_t size,
+       DataType dtype) -> std::unique_ptr<Compressor> {
+      auto iter = kwargs.find("compressor_k");
+      if (iter == kwargs.end()) {
+        BPS_LOG(FATAL) << "Randomk Compressor needs parameter \"compressor_k\"";
+      }
+      int k = std::stoi(iter->second);
+      BPS_LOG(DEBUG) << "Register Randomk Compressor "
+                     << "k=" << k;
 
-          auto iter2 = kwargs.find("seed");
-          if (iter2 == kwargs.end()) {
-            return std::unique_ptr<Compressor>(new RandomkCompressor(size, k));
-          } else {
-            unsigned int seed = std::stoul(iter2->second);
-            BPS_CHECK(seed != 0) << "seed should not be 0";
-            return std::unique_ptr<Compressor>(
-                new RandomkCompressor(size, k, seed, true));
-          }
-        });
+      auto iter2 = kwargs.find("seed");
+      if (iter2 == kwargs.end()) {
+        return std::unique_ptr<Compressor>(
+            new RandomkCompressor(size, dtype, k));
+      } else {
+        unsigned int seed = std::stoul(iter2->second);
+        BPS_CHECK(seed != 0) << "seed should not be 0";
+        return std::unique_ptr<Compressor>(
+            new RandomkCompressor(size, dtype, k, seed, true));
+      }
+    });
 }
 
 template <typename index_t, typename scalar_t>
-size_t RandomkCompressor::PackingImpl(index_t* dst, const scalar_t* src,
-                                      size_t len) {
+tensor_t RandomkCompressor::CompressImpl(index_t* dst, const scalar_t* src,
+                                         size_t len) {
   static_assert(sizeof(index_t) == sizeof(scalar_t),
                 "index_t should be the same size as scalar_t");
   BPS_CHECK_LE(this->_k, len / 2);
@@ -59,85 +59,59 @@ size_t RandomkCompressor::PackingImpl(index_t* dst, const scalar_t* src,
     ptr[i] = std::make_pair(index, src[index]);
   }
 
-  return this->_k * sizeof(pair_t);
-}
-
-size_t RandomkCompressor::Packing(const void* src, size_t size, int dtype) {
-  switch (dtype) {
-    case BYTEPS_FLOAT32:
-      return PackingImpl(reinterpret_cast<int32_t*>(_buf.get()),
-                         reinterpret_cast<const float*>(src),
-                         size / sizeof(int32_t));
-    case BYTEPS_FLOAT64:
-      return PackingImpl(reinterpret_cast<int64_t*>(_buf.get()),
-                         reinterpret_cast<const double*>(src),
-                         size / sizeof(int64_t));
-    default:
-      BPS_CHECK(0) << "Unsupported data type: " << dtype;
-  }
-  return 0;
+  return {dst, this->_k * sizeof(pair_t)};
 }
 
 tensor_t RandomkCompressor::Compress(tensor_t grad) {
-  auto compressed_size = Packing(grad.data, grad.size, grad.dtype);
-  return {_buf.get(), compressed_size};
+  COMPRESS_IMPL_SWITCH(grad.dtype, CompressImpl, _buf.get(), grad.data,
+                       grad.size);
 }
 
 template <typename index_t, typename scalar_t>
-void RandomkCompressor::UnpackingImpl(scalar_t* dst, const index_t* src,
-                                      size_t len, size_t src_len) {
+tensor_t RandomkCompressor::DecompressImpl(scalar_t* dst, const index_t* src,
+                                           size_t compressed_size) {
   static_assert(sizeof(index_t) == sizeof(scalar_t),
                 "index_t should be the same size as scalar_t");
   using pair_t = std::pair<index_t, scalar_t>;
-  auto ptr = reinterpret_cast<const pair_t*>(src);
 
+  auto ptr = reinterpret_cast<const pair_t*>(src);
   if ((void*)dst == (void*)src) {
     auto buf = reinterpret_cast<pair_t*>(_buf.get());
-    std::copy(ptr, ptr + len, buf);
+    std::memcpy(buf, ptr, compressed_size);
     ptr = const_cast<const pair_t*>(buf);
   }
 
   // reset to zeros
-  std::fill(dst, dst + src_len, 0);
+  std::memset(dst, 0, _size);
+  size_t len = compressed_size / sizeof(pair_t);
   for (auto i = 0; i < len; ++i) {
     auto& pair = ptr[i];
     dst[pair.first] = pair.second;
   }
-}
 
-void RandomkCompressor::Unpacking(void* dst, const void* src, size_t size,
-                                  size_t src_size, int dtype) {
-  switch (dtype) {
-    case BYTEPS_FLOAT32:
-      return UnpackingImpl(reinterpret_cast<float*>(dst),
-                           reinterpret_cast<const int32_t*>(src),
-                           size / sizeof(float) / 2, src_size / sizeof(float));
-    case BYTEPS_FLOAT64:
-      return UnpackingImpl(
-          reinterpret_cast<double*>(dst), reinterpret_cast<const int64_t*>(src),
-          size / sizeof(double) / 2, src_size / sizeof(double));
-    default:
-      BPS_CHECK(0) << "Unsupported data type: " << dtype;
-  }
+  return {dst, _size};
 }
 
 tensor_t RandomkCompressor::Decompress(tensor_t compressed) {
 #ifdef BYTEPS_BUILDING_SERVER
-  auto dst_ptr = _buf.get();
+  auto dst = _buf.get();
 #else
-  auto dst_ptr = compressed.data;
+  auto dst = compressed.data;
 #endif
-  Unpacking(dst_ptr, compressed.data, compressed.size, _size, compressed.dtype);
-  return {dst_ptr, _size};
+  DECOMPRESS_IMPL_SWITCH(_dtype, DecompressImpl, dst, compressed.data,
+                         compressed.size);
 }
 
 template <typename index_t, typename scalar_t>
 void RandomkCompressor::FastUpdateErrorImpl(scalar_t* error,
+                                            scalar_t* corrected,
                                             const index_t* compressed,
-                                            size_t len) {
+                                            size_t compressed_size) {
   static_assert(sizeof(index_t) == sizeof(scalar_t),
                 "index_t should be the same size as scalar_t");
   using pair_t = std::pair<index_t, scalar_t>;
+
+  std::memcpy(error, corrected, _size);
 
   auto ptr = reinterpret_cast<const pair_t*>(compressed);
   for (auto i = 0; i < this->_k; ++i) {
@@ -148,21 +122,9 @@ void RandomkCompressor::FastUpdateErrorImpl(scalar_t* error,
 
 void RandomkCompressor::FastUpdateError(tensor_t error, tensor_t corrected,
                                         tensor_t compressed) {
-  std::memcpy(error.data, corrected.data, corrected.size);
-  switch (corrected.dtype) {
-    case BYTEPS_FLOAT32:
-      return FastUpdateErrorImpl(
-          reinterpret_cast<float*>(error.data),
-          reinterpret_cast<const int32_t*>(compressed.data),
-          corrected.size / sizeof(float));
-    case BYTEPS_FLOAT64:
-      return FastUpdateErrorImpl(
-          reinterpret_cast<double*>(error.data),
-          reinterpret_cast<const int64_t*>(compressed.data),
-          corrected.size / sizeof(double));
-    default:
-      BPS_CHECK(0) << "Unsupported data type: " << corrected.dtype;
-  }
+  SWITCH_TO_FAST_UPDATE_ERROR_IMPL_SWITCH(_dtype, FastUpdateErrorImpl,
+                                          error.data, corrected.data,
+                                          compressed.data, compressed.size);
 }
 }  // namespace compressor
 }  // namespace common

--- a/byteps/common/compressor/impl/randomk.cc
+++ b/byteps/common/compressor/impl/randomk.cc
@@ -26,9 +26,8 @@ CompressorRegistry::Register
            int dtype) -> std::unique_ptr<Compressor> {
           auto iter = kwargs.find("compressor_k");
           if (iter == kwargs.end()) {
-            BPS_LOG(WARNING)
+            BPS_LOG(FATAL)
                 << "Randomk Compressor needs parameter \"compressor_k\"";
-            return nullptr;
           }
           int k = std::stoi(iter->second);
           BPS_LOG(DEBUG) << "Register Randomk Compressor "

--- a/byteps/common/compressor/impl/randomk.cc
+++ b/byteps/common/compressor/impl/randomk.cc
@@ -40,7 +40,7 @@ CompressorRegistry::Register reg(
         unsigned int seed = std::stoul(iter2->second);
         BPS_CHECK(seed != 0) << "seed should not be 0";
         return std::unique_ptr<Compressor>(
-            new RandomkCompressor(size, dtype, k, seed, true));
+            new RandomkCompressor(size, dtype, k, seed));
       }
     });
 }

--- a/byteps/common/compressor/impl/randomk.h
+++ b/byteps/common/compressor/impl/randomk.h
@@ -38,10 +38,9 @@ namespace compressor {
  */
 class RandomkCompressor : public Compressor {
  public:
-  RandomkCompressor(size_t size, DataType dtype, int k, unsigned int seed = 0,
-                    bool deterministic = false)
+  RandomkCompressor(size_t size, DataType dtype, int k, unsigned int seed = 0)
       : Compressor(size, dtype), _k(k) {
-    if (deterministic) {
+    if (seed != 0) {
       BPS_LOG(INFO) << "SET SEED = " << seed;
       _rng.set_seed(seed);
     }

--- a/byteps/common/compressor/impl/randomk.h
+++ b/byteps/common/compressor/impl/randomk.h
@@ -38,9 +38,9 @@ namespace compressor {
  */
 class RandomkCompressor : public Compressor {
  public:
-  RandomkCompressor(size_t size, int k, unsigned int seed = 0,
+  RandomkCompressor(size_t size, DataType dtype, int k, unsigned int seed = 0,
                     bool deterministic = false)
-      : Compressor(size), _k(k) {
+      : Compressor(size, dtype), _k(k) {
     if (deterministic) {
       BPS_LOG(INFO) << "SET SEED = " << seed;
       _rng.set_seed(seed);
@@ -82,21 +82,16 @@ class RandomkCompressor : public Compressor {
                        tensor_t compressed) override;
 
  private:
-  size_t Packing(const void* src, size_t size, int dtype);
+  template <typename index_t, typename scalar_t>
+  tensor_t CompressImpl(index_t* dst, const scalar_t* src, size_t len);
 
   template <typename index_t, typename scalar_t>
-  size_t PackingImpl(index_t* dst, const scalar_t* src, size_t len);
-
-  void Unpacking(void* dst, const void* src, size_t size, size_t src_size,
-                 int dtype);
+  tensor_t DecompressImpl(scalar_t* dst, const index_t* src,
+                          size_t compressed_size);
 
   template <typename index_t, typename scalar_t>
-  void UnpackingImpl(scalar_t* dst, const index_t* src, size_t len,
-                     size_t src_len);
-
-  template <typename index_t, typename scalar_t>
-  void FastUpdateErrorImpl(scalar_t* error, const index_t* compressed,
-                           size_t len);
+  void FastUpdateErrorImpl(scalar_t* error, scalar_t* corrected,
+                           const index_t* compressed, size_t compressed_size);
 
  private:
   int _k;

--- a/byteps/common/compressor/impl/topk.cc
+++ b/byteps/common/compressor/impl/topk.cc
@@ -25,7 +25,7 @@ namespace {
 CompressorRegistry::Register reg(
     "topk_compressor",
     [](const kwargs_t& kwargs, size_t size,
-       int dtype) -> std::unique_ptr<Compressor> {
+       DataType dtype) -> std::unique_ptr<Compressor> {
       auto iter = kwargs.find("compressor_k");
       if (iter == kwargs.end()) {
         BPS_LOG(FATAL) << "Topk Compressor needs parameter \"compressor_k\"";
@@ -33,13 +33,13 @@ CompressorRegistry::Register reg(
       int k = std::stoi(iter->second);
       BPS_LOG(DEBUG) << "Register Topk Compressor "
                      << "k=" << k;
-      return std::unique_ptr<Compressor>(new TopkCompressor(size, k));
+      return std::unique_ptr<Compressor>(new TopkCompressor(size, dtype, k));
     });
 }
 
 template <typename index_t, typename scalar_t>
-size_t TopkCompressor::PackingImpl(index_t* dst, const scalar_t* src,
-                                   size_t len) {
+tensor_t TopkCompressor::CompressImpl(index_t* dst, const scalar_t* src,
+                                      size_t len) {
   static_assert(sizeof(index_t) == sizeof(scalar_t),
                 "index_t should be the same size as scalar_t");
   BPS_CHECK_LE(this->_k, len / 2);
@@ -67,85 +67,58 @@ size_t TopkCompressor::PackingImpl(index_t* dst, const scalar_t* src,
     }
   }
 
-  return this->_k * sizeof(pair_t);
-}
-
-size_t TopkCompressor::Packing(const void* src, size_t size, int dtype) {
-  switch (dtype) {
-    case BYTEPS_FLOAT32:
-      return PackingImpl(reinterpret_cast<int32_t*>(_buf.get()),
-                         reinterpret_cast<const float*>(src),
-                         size / sizeof(int32_t));
-    case BYTEPS_FLOAT64:
-      return PackingImpl(reinterpret_cast<int64_t*>(_buf.get()),
-                         reinterpret_cast<const double*>(src),
-                         size / sizeof(int64_t));
-    default:
-      BPS_CHECK(0) << "Unsupported data type: " << dtype;
-  }
-  return 0;
+  return {dst, this->_k * sizeof(pair_t)};
 }
 
 tensor_t TopkCompressor::Compress(tensor_t grad) {
-  auto compressed_size = Packing(grad.data, grad.size, grad.dtype);
-  return {_buf.get(), compressed_size};
+  COMPRESS_IMPL_SWITCH(grad.dtype, CompressImpl, _buf.get(), grad.data,
+                       grad.size);
 }
 
 template <typename index_t, typename scalar_t>
-void TopkCompressor::UnpackingImpl(scalar_t* dst, const index_t* src,
-                                   size_t len, size_t src_len) {
+tensor_t TopkCompressor::DecompressImpl(scalar_t* dst, const index_t* src,
+                                        size_t compressed_size) {
   static_assert(sizeof(index_t) == sizeof(scalar_t),
                 "index_t should be the same size as scalar_t");
   using pair_t = std::pair<index_t, scalar_t>;
-  auto ptr = reinterpret_cast<const pair_t*>(src);
 
+  auto ptr = reinterpret_cast<const pair_t*>(src);
   if ((void*)dst == (void*)src) {
     auto buf = reinterpret_cast<pair_t*>(_buf.get());
-    std::copy(ptr, ptr + len, buf);
+    std::memcpy(buf, ptr, compressed_size);
     ptr = const_cast<const pair_t*>(buf);
   }
 
   // reset to zeros
-  std::fill(dst, dst + src_len, 0);
+  std::memset(dst, 0, _size);
+  size_t len = compressed_size / sizeof(pair_t);
   for (auto i = 0; i < len; ++i) {
     auto& pair = ptr[i];
     dst[pair.first] = pair.second;
   }
-}
 
-void TopkCompressor::Unpacking(void* dst, const void* src, size_t size,
-                               size_t src_size, int dtype) {
-  switch (dtype) {
-    case BYTEPS_FLOAT32:
-      return UnpackingImpl(reinterpret_cast<float*>(dst),
-                           reinterpret_cast<const int32_t*>(src),
-                           size / sizeof(float) / 2, src_size / sizeof(float));
-    case BYTEPS_FLOAT64:
-      return UnpackingImpl(
-          reinterpret_cast<double*>(dst), reinterpret_cast<const int64_t*>(src),
-          size / sizeof(double) / 2, src_size / sizeof(double));
-    default:
-      BPS_CHECK(0) << "Unsupported data type: " << dtype;
-  }
+  return {dst, _size};
 }
 
 tensor_t TopkCompressor::Decompress(tensor_t compressed) {
 #ifdef BYTEPS_BUILDING_SERVER
-  auto dst_ptr = _buf.get();
+  auto dst = _buf.get();
 #else
-  auto dst_ptr = compressed.data;
+  auto dst = compressed.data;
 #endif
-  Unpacking(dst_ptr, compressed.data, compressed.size, _size, compressed.dtype);
-  return {dst_ptr, _size};
+  DECOMPRESS_IMPL_SWITCH(_dtype, DecompressImpl, dst, compressed.data,
+                         compressed.size);
 }
 
 template <typename index_t, typename scalar_t>
-void TopkCompressor::FastUpdateErrorImpl(scalar_t* error,
+void TopkCompressor::FastUpdateErrorImpl(scalar_t* error, scalar_t* corrected,
                                          const index_t* compressed,
-                                         size_t len) {
+                                         size_t compressed_size) {
   static_assert(sizeof(index_t) == sizeof(scalar_t),
                 "index_t should be the same size as scalar_t");
   using pair_t = std::pair<index_t, scalar_t>;
+
+  std::memcpy(error, corrected, _size);
 
   auto ptr = reinterpret_cast<const pair_t*>(compressed);
   for (auto i = 0; i < this->_k; ++i) {
@@ -156,21 +129,9 @@ void TopkCompressor::FastUpdateErrorImpl(scalar_t* error,
 
 void TopkCompressor::FastUpdateError(tensor_t error, tensor_t corrected,
                                      tensor_t compressed) {
-  std::memcpy(error.data, corrected.data, corrected.size);
-  switch (corrected.dtype) {
-    case BYTEPS_FLOAT32:
-      return FastUpdateErrorImpl(
-          reinterpret_cast<float*>(error.data),
-          reinterpret_cast<const int32_t*>(compressed.data),
-          corrected.size / sizeof(float));
-    case BYTEPS_FLOAT64:
-      return FastUpdateErrorImpl(
-          reinterpret_cast<double*>(error.data),
-          reinterpret_cast<const int64_t*>(compressed.data),
-          corrected.size / sizeof(double));
-    default:
-      BPS_CHECK(0) << "Unsupported data type: " << corrected.dtype;
-  }
+  SWITCH_TO_FAST_UPDATE_ERROR_IMPL_SWITCH(_dtype, FastUpdateErrorImpl,
+                                          error.data, corrected.data,
+                                          compressed.data, compressed.size);
 }
 }  // namespace compressor
 }  // namespace common

--- a/byteps/common/compressor/impl/topk.cc
+++ b/byteps/common/compressor/impl/topk.cc
@@ -28,8 +28,7 @@ CompressorRegistry::Register reg(
        int dtype) -> std::unique_ptr<Compressor> {
       auto iter = kwargs.find("compressor_k");
       if (iter == kwargs.end()) {
-        BPS_LOG(WARNING) << "Topk Compressor needs parameter \"compressor_k\"";
-        return nullptr;
+        BPS_LOG(FATAL) << "Topk Compressor needs parameter \"compressor_k\"";
       }
       int k = std::stoi(iter->second);
       BPS_LOG(DEBUG) << "Register Topk Compressor "

--- a/byteps/common/compressor/impl/topk.h
+++ b/byteps/common/compressor/impl/topk.h
@@ -33,7 +33,8 @@ namespace compressor {
  */
 class TopkCompressor : public Compressor {
  public:
-  TopkCompressor(size_t size, int k) : Compressor(size), _k(k){};
+  TopkCompressor(size_t size, DataType dtype, int k)
+      : Compressor(size, dtype), _k(k){};
   virtual ~TopkCompressor() = default;
 
   /*!
@@ -59,8 +60,8 @@ class TopkCompressor : public Compressor {
   tensor_t Decompress(tensor_t compressed) override;
 
   /*!
-   * \brief faster version of `UpdateError` 
-   * 
+   * \brief faster version of `UpdateError`
+   *
    * 1. e <- p (e is the error and p is the corrected gradient)
    * 2. zero-fill e with selected k indices
    *
@@ -72,21 +73,16 @@ class TopkCompressor : public Compressor {
                        tensor_t compressed) override;
 
  private:
-  size_t Packing(const void* src, size_t size, int dtype);
+  template <typename index_t, typename scalar_t>
+  tensor_t CompressImpl(index_t* dst, const scalar_t* src, size_t len);
 
   template <typename index_t, typename scalar_t>
-  size_t PackingImpl(index_t* dst, const scalar_t* src, size_t len);
-
-  void Unpacking(void* dst, const void* src, size_t size, size_t src_size,
-                 int dtype);
+  tensor_t DecompressImpl(scalar_t* dst, const index_t* src,
+                          size_t compressed_size);
 
   template <typename index_t, typename scalar_t>
-  void UnpackingImpl(scalar_t* dst, const index_t* src, size_t len,
-                     size_t src_len);
-
-  template <typename index_t, typename scalar_t>
-  void FastUpdateErrorImpl(scalar_t* error, const index_t* compressed,
-                           size_t len);
+  void FastUpdateErrorImpl(scalar_t* error, scalar_t* corrected,
+                           const index_t* compressed, size_t compressed_size);
 
  private:
   int _k;

--- a/byteps/common/compressor/impl/vanilla_error_feedback.cc
+++ b/byteps/common/compressor/impl/vanilla_error_feedback.cc
@@ -28,22 +28,21 @@ namespace {
 CompressorRegistry::Register reg(
     "vanilla_ef",
     [](const kwargs_t& kwargs, size_t size,
-       int dtype) -> std::unique_ptr<Compressor> {
+       DataType dtype) -> std::unique_ptr<Compressor> {
       // register cpr
       auto kwargs_clone = kwargs;
       kwargs_clone.erase("ef_type");
-      auto cptr =
-          CompressorRegistry::Create(kwargs_clone, size, dtype);
+      auto cptr = CompressorRegistry::Create(kwargs_clone, size, dtype);
       BPS_CHECK_NE(cptr, nullptr);
       BPS_LOG(DEBUG) << "with Error feedback";
       return std::unique_ptr<VanillaErrorFeedbackCompressor>(
-          new VanillaErrorFeedbackCompressor(size, std::move(cptr)));
+          new VanillaErrorFeedbackCompressor(size, dtype, std::move(cptr)));
     });
 }
 
 VanillaErrorFeedbackCompressor::VanillaErrorFeedbackCompressor(
-    size_t size, std::unique_ptr<Compressor> cptr)
-    : ErrorFeedback(size, std::move(cptr)) {
+    size_t size, DataType dtype, std::unique_ptr<Compressor> cptr)
+    : ErrorFeedback(size, dtype, std::move(cptr)) {
   _fd = open("lr.s", O_RDONLY);
   BPS_CHECK(_fd > 0) << "open lr.s failed, errno=" << strerror(errno);
   void* ptr = mmap(0, 8, PROT_READ, MAP_SHARED, _fd, 0);

--- a/byteps/common/compressor/impl/vanilla_error_feedback.h
+++ b/byteps/common/compressor/impl/vanilla_error_feedback.h
@@ -28,31 +28,32 @@ namespace compressor {
  * paper: Communication-efficient distributed blockwise momentum sgd with
  * error-feedback
  * https://arxiv.org/pdf/1905.10936.pdf
- * 
+ *
  * each worker i:
  *    p_{t,i} <- g_{t,i} + \frac{\eta_{t-1}}{\eta_t} e_{t,i}
  *    c_{t,i} <- Compress(p_{t,i})
  *    e_{t,i} <- p_{t,i} - c_{t,i}
- * 
+ *
  * server:
- *    \tilde{p}_{t} <- \frac{1}{M} \sum_{i=1}^{M} c_{t,i} +\frac{\eta_{t-1}}{\eta_{t}} \tilde{e_t}
- *    \tilde{e}_{t+1} <- \tilde{p}_{t}-\tilde{c_t}
- * 
+ *    \tilde{p}_{t} <- \frac{1}{M} \sum_{i=1}^{M} c_{t,i}
+ * +\frac{\eta_{t-1}}{\eta_{t}} \tilde{e_t} \tilde{e}_{t+1} <-
+ * \tilde{p}_{t}-\tilde{c_t}
+ *
  * Error-correction: error needs to be scaled with \frac{\eta_{t-1}}{\eta_t}.
  */
 class VanillaErrorFeedbackCompressor : public ErrorFeedback {
  public:
-  VanillaErrorFeedbackCompressor(size_t size, std::unique_ptr<Compressor> cptr);
+  VanillaErrorFeedbackCompressor(size_t size, DataType dtype,
+                                 std::unique_ptr<Compressor> cptr);
   virtual ~VanillaErrorFeedbackCompressor();
 
  protected:
- 
   void UpdateGradient(tensor_t grad) override;
 
  private:
   /*!
    * \brief learning rate
-   * 
+   *
    * read from file each step
    */
   double _pre_lr, _cur_lr;

--- a/byteps/common/compressor/momentum.h
+++ b/byteps/common/compressor/momentum.h
@@ -36,14 +36,15 @@ namespace compressor {
  * \note
  * The framework's momentum is disabled when using this momentum. User do not
  * need to disable it manully.
- * 
+ *
  * \sa Compressor, NesterovMomentumCompressor
  */
 class Momentum : public Compressor {
  public:
   // momentum should be cleared to zeros
-  Momentum(size_t size, std::unique_ptr<Compressor> cptr, float mu)
-      : Compressor(size),
+  Momentum(size_t size, DataType dtype, std::unique_ptr<Compressor> cptr,
+           float mu)
+      : Compressor(size, dtype),
         _cptr(std::move(cptr)),
         _mu(mu),
         _mom(new byte_t[size]()){};
@@ -75,7 +76,7 @@ class Momentum : public Compressor {
  protected:
   /*! \brief buffer of momentum */
   std::unique_ptr<byte_t[]> _mom;
-  
+
   /*! \brief momentum factor */
   float _mu;
 

--- a/byteps/common/operations.cc
+++ b/byteps/common/operations.cc
@@ -372,8 +372,8 @@ void InitTensor(BPSContext &context, size_t size, int dtype, void *cpubuff) {
 
       // register
       if (!context.kwargs.empty()) {
-        auto compressor_ptr =
-            compressor::CompressorRegistry::Create(context.kwargs, Align(len, dtype), dtype);
+        auto compressor_ptr = compressor::CompressorRegistry::Create(
+            context.kwargs, Align(len, dtype), static_cast<DataType>(dtype));
         context.compressor_list.push_back(std::move(compressor_ptr));
       }
     }

--- a/byteps/server/server.cc
+++ b/byteps/server/server.cc
@@ -229,7 +229,8 @@ void BytePSHandler(const ps::KVMeta& req_meta,
       size_t aligned_size = byteps::common::Align(stored->len, stored->dtype);
       auto compressor_ptr =
           byteps::common::compressor::CompressorRegistry::Create(
-              kwargs, aligned_size, stored->dtype);
+              kwargs, aligned_size,
+              static_cast<byteps::common::DataType>(stored->dtype));
       CHECK_NE(compressor_ptr, nullptr);
       compressor_map_[key] = std::move(compressor_ptr);
       if (log_key_info_) {


### PR DESCRIPTION
## brief 

use macros to make code more readable and easy to maintain.
```c++
#define COMPRESS_IMPL_SWITCH(dtype, func, dst, src, size)                     \
  switch (dtype) {                                                            \
    case BYTEPS_FLOAT32:                                                      \
      return func(reinterpret_cast<uint32_t*>(dst),                           \
                  reinterpret_cast<const float*>(src), size / sizeof(float)); \
    case BYTEPS_FLOAT64:                                                      \
      return func(reinterpret_cast<uint64_t*>(dst),                           \
                  reinterpret_cast<const double*>(src),                       \
                  size / sizeof(double));                                     \
    default:                                                                  \
      BPS_CHECK(0) << "Unsupported data type:" << dtype;                      \
  }

#define DECOMPRESS_IMPL_SWITCH(dtype, func, dst, src, compressed_size)      \
  switch (dtype) {                                                          \
    case BYTEPS_FLOAT32:                                                    \
      return func(reinterpret_cast<float*>(dst),                            \
                  reinterpret_cast<const uint32_t*>(src), compressed_size); \
    case BYTEPS_FLOAT64:                                                    \
      return func(reinterpret_cast<double*>(dst),                           \
                  reinterpret_cast<const uint64_t*>(src), compressed_size); \
    default:                                                                \
      BPS_CHECK(0) << "Unsupported data type:" << dtype;                    \
  }

#define SWITCH_TO_FAST_UPDATE_ERROR_IMPL_SWITCH(dtype, func, dst, src1, src2, \
                                                compressed_size)              \
  switch (dtype) {                                                            \
    case BYTEPS_FLOAT32:                                                      \
      return func(reinterpret_cast<float*>(dst),                              \
                  reinterpret_cast<float*>(src1),                             \
                  reinterpret_cast<const uint32_t*>(src2), compressed_size);  \
    case BYTEPS_FLOAT64:                                                      \
      return func(reinterpret_cast<double*>(dst),                             \
                  reinterpret_cast<double*>(src1),                            \
                  reinterpret_cast<const uint64_t*>(src2), compressed_size);  \
    default:                                                                  \
      BPS_CHECK(0) << "Unsupported data type:" << dtype;                      \
  }


```