### PR TITLE
reduce: add omp num threads recommendation

### DIFF
--- a/byteps/common/compressor/compressor.h
+++ b/byteps/common/compressor/compressor.h
@@ -18,7 +18,8 @@
 
 #include <memory>
 
-#include "../cpu_reducer.h"
+#include "../common.h"
+#include "../logging.h"
 #include "common.h"
 
 namespace byteps {
@@ -52,10 +53,7 @@ namespace compressor {
 class Compressor {
  public:
   Compressor(size_t size, DataType dtype)
-      : _size(size),
-        _dtype(dtype),
-        _buf(new byte_t[size]),
-        _cpu_reducer(new CpuReducer(nullptr)){};
+      : _size(size), _dtype(dtype), _buf(new byte_t[size]){};
   virtual ~Compressor() = default;
 
   /*!
@@ -126,9 +124,6 @@ class Compressor {
 
   /*! \brief buffer to store compressed grad */
   std::unique_ptr<byte_t[]> _buf;
-
-  /*! \brief CPU reducer */
-  std::unique_ptr<CpuReducer> _cpu_reducer;
 };
 
 }  // namespace compressor

--- a/byteps/common/compressor/error_feedback.h
+++ b/byteps/common/compressor/error_feedback.h
@@ -16,6 +16,7 @@
 #ifndef BYTEPS_COMPRESSOR_ERROR_FEEDBACK_H
 #define BYTEPS_COMPRESSOR_ERROR_FEEDBACK_H
 
+#include "../cpu_reducer.h"
 #include "compressor.h"
 
 namespace byteps {
@@ -51,6 +52,7 @@ class ErrorFeedback : public Compressor {
   ErrorFeedback(size_t size, DataType dtype, std::unique_ptr<Compressor> cptr)
       : Compressor(size, dtype),
         _error(new byte_t[size]()),
+        _cpu_reducer(new CpuReducer(nullptr)),
         _cptr(std::move(cptr)) {}
   virtual ~ErrorFeedback() = default;
 
@@ -84,6 +86,8 @@ class ErrorFeedback : public Compressor {
  protected:
   /*! \brief buffer of error */
   std::unique_ptr<byte_t[]> _error;
+
+  std::unique_ptr<CpuReducer> _cpu_reducer;
 
  private:
   /*! \brief compressor pointer */

--- a/byteps/common/compressor/impl/dithering.cc
+++ b/byteps/common/compressor/impl/dithering.cc
@@ -14,6 +14,7 @@
 // =============================================================================
 
 #include <cmath>
+#include <cstring>
 
 #include "../compressor_registry.h"
 #include "dithering.h"
@@ -54,12 +55,10 @@ tensor_t DitheringCompressor::CompressImpl(index_t* dst, const scalar_t* src,
   // normalize
   double scale = 0.0;
   if (_ntype == NomalizeType::MAX) {
-#pragma omp parallel for simd reduction(max : scale)
     for (size_t i = 0; i < len; i++) {
       scale = scale > std::abs(src[i]) ? scale : std::abs(src[i]);
     }
   } else if (_ntype == NomalizeType::L2) {
-#pragma omp parallel for simd num_threads(4) reduction(+ : scale)
     for (size_t i = 0; i < len; ++i) {
       scale += src[i] * src[i];
     }

--- a/byteps/common/compressor/impl/nesterov_momentum.cc
+++ b/byteps/common/compressor/impl/nesterov_momentum.cc
@@ -30,7 +30,7 @@ CompressorRegistry::Register reg(
       auto cptr = CompressorRegistry::Create(kwargs_clone, size, dtype);
       BPS_CHECK_NE(cptr, nullptr);
       // find \mu
-      auto mu = HyperParamFinder<float>(kwargs, "compressor_mu");
+      auto mu = HyperParamFinder<float>(kwargs, "momentum_mu");
       return std::unique_ptr<NesterovMomentumCompressor>(
           new NesterovMomentumCompressor(size, dtype, std::move(cptr), mu));
     });

--- a/byteps/common/compressor/impl/onebit.cc
+++ b/byteps/common/compressor/impl/onebit.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 // =============================================================================
 
+#include <cstring>
+
 #include "onebit.h"
 #include "../compressor_registry.h"
 
@@ -41,14 +43,13 @@ tensor_t OnebitCompressor::CompressImpl(index_t* dst, const scalar_t* src,
   float scale = 1.0f;
   if (_use_scale) {
     double sum = 0.0f;
-#pragma omp parallel for simd num_threads(4) reduction(+ : sum)
     for (size_t i = 0; i < len; ++i) {
       sum += std::abs(src[i]);
     }
     scale = sum / len;
   }
 
-#pragma omp parallel for simd num_threads(4)
+#pragma omp parallel for simd
   for (size_t i = 0; i < chunk_len; ++i) {
     index_t x = src[i * PACKING_SIZE] < 0;
     for (size_t j = 1; j < PACKING_SIZE; ++j) {
@@ -86,7 +87,7 @@ tensor_t OnebitCompressor::DecompressImpl(scalar_t* dst, const index_t* src,
     std::memcpy(ptr, src, compressed_size);
   }
 
-#pragma omp parallel for simd num_threads(4)
+#pragma omp parallel for simd
   for (int i = chunk_len - 1; i >= 0; --i) {
     index_t x = ptr[i];
     for (int j = PACKING_SIZE - 1; j >= 0; --j) {
@@ -119,7 +120,7 @@ void OnebitCompressor::FastUpdateErrorImpl(scalar_t* error, scalar_t* corrected,
   auto* pf = reinterpret_cast<const float*>(compressed + chunk_len);
   float scale = *pf;
 
-#pragma omp parallel for simd num_threads(4)
+#pragma omp parallel for simd
   for (int i = chunk_len - 1; i >= 0; --i) {
     index_t x = compressed[i];
     for (int j = PACKING_SIZE - 1; j >= 0; --j) {

--- a/byteps/common/compressor/impl/randomk.cc
+++ b/byteps/common/compressor/impl/randomk.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 // =============================================================================
 
+#include <cstring>
+
 #include "randomk.h"
 #include "../compressor_registry.h"
 

--- a/byteps/common/compressor/impl/topk.cc
+++ b/byteps/common/compressor/impl/topk.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 // =============================================================================
 
+#include <cstring>
 #include <queue>
 
 #include "../compressor_registry.h"

--- a/byteps/common/compressor/momentum.h
+++ b/byteps/common/compressor/momentum.h
@@ -16,6 +16,7 @@
 #ifndef BYTEPS_COMPRESSOR_MOMENTUM_H
 #define BYTEPS_COMPRESSOR_MOMENTUM_H
 
+#include "../cpu_reducer.h"
 #include "compressor.h"
 
 namespace byteps {
@@ -47,6 +48,7 @@ class Momentum : public Compressor {
       : Compressor(size, dtype),
         _mom(new byte_t[size]()),
         _mu(mu),
+        _cpu_reducer(new CpuReducer(nullptr)),
         _cptr(std::move(cptr)){};
   virtual ~Momentum() = default;
 
@@ -79,6 +81,8 @@ class Momentum : public Compressor {
 
   /*! \brief momentum factor */
   float _mu;
+
+  std::unique_ptr<CpuReducer> _cpu_reducer;
 
  private:
   /*! \brief compressor pointer */

--- a/byteps/common/cpu_reducer.h
+++ b/byteps/common/cpu_reducer.h
@@ -63,6 +63,14 @@ class CpuReducer {
   DataType GetDataType(int dtype) { return static_cast<DataType>(dtype); }
 
  private:
+  size_t GetRecommendNumThreads(size_t len) const {
+    if (len < _single_thread_threshold) {
+      return 1;
+    } else {
+      return _num_threads;
+    }
+  }
+
 #if __AVX__ && __F16C__
   // Query CPUID to determine AVX and F16C runtime support.
   bool is_avx_and_f16c() {
@@ -200,6 +208,7 @@ class CpuReducer {
 
   std::shared_ptr<BytePSComm> _comm;
   int _num_threads;
+  size_t _single_thread_threshold; 
 };
 
 }  // namespace common


### PR DESCRIPTION
add a new env: `BYTEPS_OMP_THREAD_THRESHOLD`. tensor smaller than the threshold will only use 1 omp thread (disable omp). 