### PR TITLE
1bit: don't do wd mom for uncompressed gradients

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -279,10 +279,10 @@ class DistributedTrainer(mx.gluon.Trainer):
         # to avoid duplication
         if compression_params.get("momentum"):
             # 1bit compressor use an additional momentum for weight decay
-            if compressor == "onebit" and "wd" in optimizer_params:
-                intra_compressor = Compression.wdmom(
-                    intra_compressor, optimizer_params["momentum"], optimizer_params["wd"])
-                del optimizer_params["wd"]
+            # if compressor == "onebit" and "wd" in optimizer_params:
+            #     intra_compressor = Compression.wdmom(
+            #         intra_compressor, optimizer_params["momentum"], optimizer_params["wd"])
+            #     del optimizer_params["wd"]
 
             del optimizer_params['momentum']
 


### PR DESCRIPTION
I found 1bit with wd mom is extreamly slow compared to the one without wd mom. Since i have set a threshold, those uncompressed gradients do not need to be applied to wd mom...

results show there is a great performance improve.