### PR TITLE
1bit: not need to do wd mom for uncompressed gradients

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -266,6 +266,8 @@ class DistributedTrainer(mx.gluon.Trainer):
                 # raise KeyError if 'k' is not found
                 setattr(param, "byteps_compressor_k",
                         compression_params["k"])
+            else:
+                raise ValueError("Unsupported compressor %s" % compressor)
 
             if compression_params.get("momentum"):
                 setattr(param, "byteps_momentum_mu",
@@ -280,8 +282,11 @@ class DistributedTrainer(mx.gluon.Trainer):
         if compression_params.get("momentum"):
             # 1bit compressor use an additional momentum for weight decay
             if compressor == "onebit" and "wd" in optimizer_params:
-                intra_compressor = Compression.wdmom(
-                    intra_compressor, optimizer_params["momentum"], optimizer_params["wd"])
+                threshold = os.environ.get("BYTEPS_MIN_COMPRESS_BYTES", 65536)
+                mu = optimizer_params["momentum"]
+                wd = optimizer_params["wd"]
+                intra_compressor = Compression.wdmom(intra_compressor,
+                                                     mu, wd, threshold)
                 del optimizer_params["wd"]
 
             del optimizer_params['momentum']

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -282,7 +282,7 @@ class DistributedTrainer(mx.gluon.Trainer):
         if compression_params.get("momentum"):
             # 1bit compressor use an additional momentum for weight decay
             if compressor == "onebit" and "wd" in optimizer_params:
-                threshold = os.environ.get("BYTEPS_MIN_COMPRESS_BYTES", 65536)
+                threshold = int(os.environ.get("BYTEPS_MIN_COMPRESS_BYTES", 65536))
                 mu = optimizer_params["momentum"]
                 wd = optimizer_params["wd"]
                 intra_compressor = Compression.wdmom(intra_compressor,

--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -266,8 +266,6 @@ class DistributedTrainer(mx.gluon.Trainer):
                 # raise KeyError if 'k' is not found
                 setattr(param, "byteps_compressor_k",
                         compression_params["k"])
-            else:
-                raise ValueError("Unsupported compressor %s" % compressor)
 
             if compression_params.get("momentum"):
                 setattr(param, "byteps_momentum_mu",

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -76,7 +76,7 @@ class WeightDecayMomentum(Compressor):
 
     @staticmethod
     def size(tensor):
-        return reduce(lambda x, y: x*y, tensor.shape)
+        return reduce(lambda x, y: x*y, tensor.shape) * 4
 
     def compress(self, tensor, *args, **kwargs):
         """Returns the tensor unmodified."""
@@ -91,22 +91,22 @@ class WeightDecayMomentum(Compressor):
             return self.compressor.decompress(tensor, ctx)
 
         x = kwargs["x"].astype(tensor.dtype, copy=False)
-        
+
         if self.cache is None:
             self.cache = nd.zeros_like(tensor)
-        
+
         # normal weight decay
         nd._internal._mul_scalar(x, self.wd, out=self.cache)
-        
+
         # weight decay momentum
         if self.size(tensor) >= self.threshold:
             if self.mom is None:
                 self.mom = nd.zeros_like(tensor)
-            
+
             self.mom += self.cache
             nd._internal._mul_scalar(self.mom, self.mu, out=self.mom)
             tensor += self.mom
-        
+
         tensor += self.cache
         return self.compressor.decompress(tensor, ctx)
 

--- a/byteps/mxnet/compression.py
+++ b/byteps/mxnet/compression.py
@@ -87,11 +87,15 @@ class WeightDecayMomentum(Compressor):
             m_t = \mu * m_{t-1} + wd * x_t
             x_{t+1} = x_t - \eta_t (tensor + \mu m_t + wd * x_t)
         """
-        # not need to do wd mom for uncompressed gradients
-        if self.size(tensor) < self.threshold or "x" not in kwargs:
+        if "x" not in kwargs:
             return self.compressor.decompress(tensor, ctx)
 
         x = kwargs["x"].astype(tensor.dtype, copy=False)
+
+        # normal weight decay
+        if self.size(tensor) < self.threshold:
+            tensor += self.wd * x
+            return self.compressor.decompress(tensor, ctx)
 
         if self.mom is None:
             self.mom = nd.zeros_like(tensor)


### PR DESCRIPTION
Since I have set a threshold, not all gradients are compressed by 1bit. For those uncompressed gradients, which are typically small tensors, there is no need to do wd mom for them. Instead, just normal weight decay is enough.


It is a waste of GPUs to do wd mom for all and may bring unknow results. e.g. hurting accuracy?  Results show there is a significant performance gain.  